### PR TITLE
future carbs 4h for dev

### DIFF
--- a/future_carbs_4h/zdev_future_carbs_4h.patch
+++ b/future_carbs_4h/zdev_future_carbs_4h.patch
@@ -1,0 +1,14 @@
+Submodule Loop contains modified content
+diff --git a/Loop/Loop/Models/LoopConstants.swift b/Loop/Loop/Models/LoopConstants.swift
+index a62fc138..795c5a6e 100644
+--- a/Loop/Loop/Models/LoopConstants.swift
++++ b/Loop/Loop/Models/LoopConstants.swift
+@@ -25,7 +25,7 @@ enum LoopConstants {
+     static let maxCarbAbsorptionTime = TimeInterval(hours: 8)
+     
+     static let maxCarbEntryPastTime = TimeInterval(hours: (-12))
+-    static let maxCarbEntryFutureTime = TimeInterval(hours: 1)
++    static let maxCarbEntryFutureTime = TimeInterval(hours: 4)
+ 
+     static let maxOverrideDurationTime = TimeInterval(hours: 24)
+     


### PR DESCRIPTION
Future carbs 4h for dev, intentionally named z to be sorted after main in order to get the main patch prioritized. 