### PR TITLE
Fix for Profile Name Issue in Nightscout Integration

### DIFF
--- a/2002/archive/2024-01-19-dev_2002.patch
+++ b/2002/archive/2024-01-19-dev_2002.patch
@@ -74,7 +74,6 @@ index c3ec98b8..74045900 100644
              ForEach(pluginMenuItems.filter {$0.section == .configuration}) { item in
                  item.view
              }
-Submodule LoopKit contains modified content
 Submodule LoopKit 70d1860..4e09f44:
 diff --git a/LoopKit/LoopKit.xcodeproj/project.pbxproj b/LoopKit/LoopKit.xcodeproj/project.pbxproj
 index 8354209..f061a30 100644
@@ -177,10 +176,10 @@ index 8354209..f061a30 100644
  				B41A60AF23D1DB5B00636320 /* TableViewTitleLabel.swift in Sources */,
 diff --git a/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
 new file mode 100644
-index 0000000..56dc952
+index 0000000..ff45860
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
-@@ -0,0 +1,400 @@
+@@ -0,0 +1,389 @@
 +//
 +//  ProfileViewModel+FileManagement.swift
 +//  LoopKitUI
@@ -274,25 +273,16 @@ index 0000000..56dc952
 +        return try JSONDecoder().decode(Profile.self, from: data)
 +    }
 +
-+    public func sanitizeProfileName(_ name: String) -> String {
-+        // Replace problematic characters
-+        var sanitized = name.replacingOccurrences(of: ".", with: "_")
-+        
-+        return sanitized
-+    }
-+
 +    public func saveProfile(withName name: String) {
-+        let sanitizedName = sanitizeProfileName(name)
-+
 +        do {
 +            try createProfileDirectoryIfNotExists()
 +
-+            if let existingProfile = getProfileReference(withName: sanitizedName) {
++            if let existingProfile = getProfileReference(withName: name) {
 +                removeProfile(profileReference: existingProfile)
 +            }
 +
 +            let profile = Profile(
-+                name: sanitizedName,
++                name: name,
 +                correctionRange: (therapySettings.glucoseTargetRangeSchedule?.schedule(for: .milligramsPerDeciliter)!)!,
 +                carbRatioSchedule: therapySettings.carbRatioSchedule!,
 +                basalRateSchedule: therapySettings.basalRateSchedule!,
@@ -308,7 +298,7 @@ index 0000000..56dc952
 +            let fileURL = profilesDirectory.appendingPathComponent(fileName)
 +
 +            try jsonData.write(to: fileURL)
-+            setCurrentProfile(name: sanitizedName, syncChange: true)
++            setCurrentProfile(name: name, syncChange: true)
 +
 +            self.loadProfiles()
 +        } catch {
@@ -317,38 +307,36 @@ index 0000000..56dc952
 +    }
 +
 +    public func renameProfile(oldName: String, newName: String) {
-+        let sanitizedProfileName = sanitizeProfileName(newName)
-+
 +        if currentProfileName == oldName {
-+            setCurrentProfile(name: sanitizedProfileName, syncChange: true)
++            currentProfileName = newName
 +        }
-+
++        
 +        do {
 +            guard let profileReference = getProfileReference(withName: oldName) else {
 +                print("Profile with old name not found.")
 +                return
 +            }
-+
++            
 +            let profile = try getProfile(from: profileReference)
-+
++            
 +            let newProfile = Profile(
-+                name: sanitizedProfileName,
++                name: newName,
 +                correctionRange: profile.correctionRange,
 +                carbRatioSchedule: profile.carbRatioSchedule,
 +                basalRateSchedule: profile.basalRateSchedule,
 +                insulinSensitivitySchedule: profile.insulinSensitivitySchedule,
 +                sortOrder: profile.sortOrder
 +            )
-+
-+            if let existingProfile = getProfileReference(withName: sanitizedProfileName) {
++            
++            if let existingProfile = getProfileReference(withName: newName) {
 +                removeProfile(profileReference: existingProfile)
 +            }
-+
++            
 +            let jsonData = try encodeProfile(newProfile)
 +            let fileURL = profilesDirectory.appendingPathComponent(profileReference.fileName)
-+
++            
 +            try jsonData.write(to: fileURL)
-+
++            
 +            self.loadProfiles()
 +        } catch {
 +            print("An error occurred while renaming profile: \(error)")

--- a/2002/archive/2024-01-19-main_2002.patch
+++ b/2002/archive/2024-01-19-main_2002.patch
@@ -1,9 +1,9 @@
-Submodule Loop b6610a1..6e6b0f2:
+Submodule Loop c6b058b..df945eb:
 diff --git a/Loop/Loop/Managers/DeviceDataManager.swift b/Loop/Loop/Managers/DeviceDataManager.swift
-index 2751f18f..4866c85c 100644
+index 4e1cbfdf..30de494f 100644
 --- a/Loop/Loop/Managers/DeviceDataManager.swift
 +++ b/Loop/Loop/Managers/DeviceDataManager.swift
-@@ -1636,6 +1636,10 @@ extension DeviceDataManager: TherapySettingsViewModelDelegate {
+@@ -1754,6 +1754,10 @@ extension DeviceDataManager: TherapySettingsViewModelDelegate {
          }
      }
      
@@ -15,7 +15,7 @@ index 2751f18f..4866c85c 100644
  
          loopManager.mutateSettings { settings in
 diff --git a/Loop/Loop/Managers/LoopDataManager.swift b/Loop/Loop/Managers/LoopDataManager.swift
-index 2319f4ec..63164e69 100644
+index 18a08166..8f1f44c6 100644
 --- a/Loop/Loop/Managers/LoopDataManager.swift
 +++ b/Loop/Loop/Managers/LoopDataManager.swift
 @@ -229,6 +229,10 @@ final class LoopDataManager {
@@ -30,57 +30,64 @@ index 2319f4ec..63164e69 100644
          var oldValue: LoopSettings!
          let newValue = lockedSettings.mutate { settings in
 diff --git a/Loop/Loop/Views/SettingsView.swift b/Loop/Loop/Views/SettingsView.swift
-index c3ec98b8..74045900 100644
+index 8fca5668..1b7828c8 100644
 --- a/Loop/Loop/Views/SettingsView.swift
 +++ b/Loop/Loop/Views/SettingsView.swift
-@@ -51,6 +51,7 @@ public struct SettingsView: View {
-             
-             case favoriteFoods
-             case therapySettings
-+            case profiles
-         }
-     }
-     
-@@ -157,6 +158,19 @@ public struct SettingsView: View {
-                     .environment(\.insulinTintColor, self.insulinTintColor)
-                 case .favoriteFoods:
-                     FavoriteFoodsView()
-+                case .profiles:
-+                    ProfileView(viewModel: ProfileViewModel(therapySettings: self.viewModel.therapySettings(),
-+                                                            sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
-+                                                            adultChildInsulinModelSelectionEnabled: FeatureFlags.adultChildInsulinModelSelectionEnabled,
-+                                                            delegate: self.viewModel.therapySettingsViewModelDelegate))
-+                    .environmentObject(displayGlucosePreference)
-+                    .environment(\.dismissAction, self.dismiss)
-+                    .environment(\.appName, self.appName)
-+                    .environment(\.chartColorPalette, .primary)
-+                    .environment(\.carbTintColor, self.carbTintColor)
-+                    .environment(\.glucoseTintColor, self.glucoseTintColor)
-+                    .environment(\.guidanceColors, self.guidanceColors)
-+                    .environment(\.insulinTintColor, self.insulinTintColor)
-                 }
+@@ -24,6 +24,7 @@ public struct SettingsView: View {
+     @ObservedObject var viewModel: SettingsViewModel
+     @ObservedObject var versionUpdateViewModel: VersionUpdateViewModel
+ 
++    @State private var profilesIsPresented: Bool = false
+     @State private var pumpChooserIsPresented: Bool = false
+     @State private var cgmChooserIsPresented: Bool = false
+     @State private var serviceChooserIsPresented: Bool = false
+@@ -150,7 +151,11 @@ extension SettingsView {
              }
          }
-@@ -294,7 +308,11 @@ extension SettingsView {
-                             imageView: Image("Therapy Icon"),
-                             label: NSLocalizedString("Therapy Settings", comment: "Title text for button to Therapy Settings"),
-                             descriptiveText: NSLocalizedString("Diabetes Treatment", comment: "Descriptive text for Therapy Settings"))
+     }
+-        
++
++    private var isAnySheetPresented: Bool {
++        therapySettingsIsPresented || profilesIsPresented
++    }
++
+     private var configurationSection: some View {
+         Section(header: SectionHeader(label: NSLocalizedString("Configuration", comment: "The title of the Configuration section in settings"))) {
+             LargeButton(action: { self.therapySettingsIsPresented = true },
+@@ -173,7 +178,26 @@ extension SettingsView {
+                         .environment(\.guidanceColors, self.guidanceColors)
+                         .environment(\.insulinTintColor, self.insulinTintColor)
+             }
 -            
-+            LargeButton(action: { sheet = .profiles },
++            LargeButton(action: { self.profilesIsPresented = true },
 +                        includeArrow: true,
 +                        imageView: AnyView(Image(systemName: "arrow.triangle.2.circlepath").font(.system(size: 30, weight: .bold))),
 +                        label: NSLocalizedString("Profiles", comment: "Title text for button to Profiles"),
 +                        descriptiveText: NSLocalizedString("Switch between profiles for different scenarios", comment: "Descriptive text for Profiles"))
-             ForEach(pluginMenuItems.filter {$0.section == .configuration}) { item in
++            .sheet(isPresented: $profilesIsPresented) {
++                ProfileView(viewModel: ProfileViewModel(therapySettings: self.viewModel.therapySettings(),
++                                                        sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
++                                                        adultChildInsulinModelSelectionEnabled: FeatureFlags.adultChildInsulinModelSelectionEnabled,
++                                                        delegate: self.viewModel.therapySettingsViewModelDelegate))
++                .environmentObject(displayGlucoseUnitObservable)
++                .environment(\.dismissAction, self.dismiss)
++                .environment(\.appName, self.appName)
++                .environment(\.chartColorPalette, .primary)
++                .environment(\.carbTintColor, self.carbTintColor)
++                .environment(\.glucoseTintColor, self.glucoseTintColor)
++                .environment(\.guidanceColors, self.guidanceColors)
++                .environment(\.insulinTintColor, self.insulinTintColor)
++            }
++
+             ForEach(configurationMenuItemsForSupportPlugins) { item in
                  item.view
              }
-Submodule LoopKit contains modified content
-Submodule LoopKit 70d1860..4e09f44:
+Submodule LoopKit 9835a29..8a58d2e:
 diff --git a/LoopKit/LoopKit.xcodeproj/project.pbxproj b/LoopKit/LoopKit.xcodeproj/project.pbxproj
-index 8354209..f061a30 100644
+index 6b13fc8..c6bcc64 100644
 --- a/LoopKit/LoopKit.xcodeproj/project.pbxproj
 +++ b/LoopKit/LoopKit.xcodeproj/project.pbxproj
-@@ -864,6 +864,12 @@
+@@ -787,6 +787,12 @@
  		C1FAEC1D264AD6B400A3250B /* DeviceStatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FAEC1C264AD6B400A3250B /* DeviceStatusBadge.swift */; };
  		C1FAEC1F264AE12700A3250B /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47ECF8725DC20810024A54D /* UIImage.swift */; };
  		C1FAEC21264AEEA300A3250B /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FAEC20264AEEA300A3250B /* UIImage.swift */; };
@@ -89,11 +96,11 @@ index 8354209..f061a30 100644
 +		DD7122612A1D2AA4004FE653 /* ProfilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7122602A1D2AA4004FE653 /* ProfilePreviewView.swift */; };
 +		DDAF746729F422C600719F0A /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAF746629F422C600719F0A /* ProfileView.swift */; };
 +		DDAF746929F4234000719F0A /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAF746829F4234000719F0A /* ProfileViewModel.swift */; };
-+		DDCFC91E2AA9F702003DE656 /* RenameProfileEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCFC91D2AA9F702003DE656 /* RenameProfileEditor.swift */; };
++		DDEACA2A2AAF797F00E57735 /* RenameProfileEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEACA292AAF797F00E57735 /* RenameProfileEditor.swift */; };
  		E9077D2724ACD59F0066A88D /* InformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9077D2624ACD59F0066A88D /* InformationView.swift */; };
  		E9077D2A24ACDE2C0066A88D /* CorrectionRangeInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9077D2924ACDE2C0066A88D /* CorrectionRangeInformationView.swift */; };
  		E9086B2924B39EDC0062F5C8 /* ChartsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B2824B39EDC0062F5C8 /* ChartsTableViewController.swift */; };
-@@ -1923,6 +1929,12 @@
+@@ -1763,6 +1769,12 @@
  		C1FDCC0A29C786F90056E652 /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/Localizable.strings; sourceTree = "<group>"; };
  		C1FDCC0B29C786F90056E652 /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/Localizable.strings; sourceTree = "<group>"; };
  		C1FF3D4E29C786A900BDC1EC /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -102,17 +109,17 @@ index 8354209..f061a30 100644
 +		DD7122602A1D2AA4004FE653 /* ProfilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePreviewView.swift; sourceTree = "<group>"; };
 +		DDAF746629F422C600719F0A /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 +		DDAF746829F4234000719F0A /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
-+		DDCFC91D2AA9F702003DE656 /* RenameProfileEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameProfileEditor.swift; sourceTree = "<group>"; };
++		DDEACA292AAF797F00E57735 /* RenameProfileEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameProfileEditor.swift; sourceTree = "<group>"; };
  		E9077D2624ACD59F0066A88D /* InformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationView.swift; sourceTree = "<group>"; };
  		E9077D2924ACDE2C0066A88D /* CorrectionRangeInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeInformationView.swift; sourceTree = "<group>"; };
  		E9086B2824B39EDC0062F5C8 /* ChartsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartsTableViewController.swift; sourceTree = "<group>"; };
-@@ -3167,11 +3179,13 @@
+@@ -2942,11 +2954,13 @@
  			isa = PBXGroup;
  			children = (
  				B455F3A325FF7FF0000ED456 /* CorrectionRangeOverridesEditorViewModel.swift */,
 +				DDAF746829F4234000719F0A /* ProfileViewModel.swift */,
  				B4B7C1BB2604E3FC007379F6 /* CorrectionRangeScheduleEditorViewModel.swift */,
- 				B4D4C20C25F95A8700DA809D /* DisplayGlucosePreference.swift */,
+ 				B4D4C20C25F95A8700DA809D /* DisplayGlucoseUnitObservable.swift */,
  				B455F48025FF9A8B000ED456 /* InsulinSensitivityScheduleEditorViewModel.swift */,
  				B455F2A125FBE985000ED456 /* SuspendThresholdEditorViewModel.swift */,
  				1D1FCE2424BD42EF000300A8 /* TherapySettingsViewModel.swift */,
@@ -120,18 +127,18 @@ index 8354209..f061a30 100644
  			);
  			path = ViewModels;
  			sourceTree = "<group>";
-@@ -3358,6 +3372,10 @@
+@@ -3077,6 +3091,10 @@
  				E96DCB5924AF74AC007117BC /* SuspendThresholdEditor.swift */,
  				1D1FCE2A24BE704A000300A8 /* TherapySetting+Settings.swift */,
  				1D1A019D24B678BF0077D86E /* TherapySettingsView.swift */,
 +				DDAF746629F422C600719F0A /* ProfileView.swift */,
 +				DD508E072A17763700EEF8FD /* NewProfileEditor.swift */,
 +				DD7122602A1D2AA4004FE653 /* ProfilePreviewView.swift */,
-+				DDCFC91D2AA9F702003DE656 /* RenameProfileEditor.swift */,
++				DDEACA292AAF797F00E57735 /* RenameProfileEditor.swift */,
  			);
  			path = "Settings Editors";
  			sourceTree = "<group>";
-@@ -4062,6 +4080,7 @@
+@@ -3757,6 +3775,7 @@
  				E9086B4824B5405E0062F5C8 /* ChartAxisValueDoubleUnit.swift in Sources */,
  				B429D66C24BF7204003E1B4A /* GlucoseTrend.swift in Sources */,
  				432CF86720D76AB90066B889 /* SettingsTableViewCell.swift in Sources */,
@@ -139,27 +146,26 @@ index 8354209..f061a30 100644
  				898B4E7B246DC6A70053C484 /* CorrectionRangeScheduleEditor.swift in Sources */,
  				E9E5E56A24D5CCE800B5DFFE /* OverrideViewCell.swift in Sources */,
  				892A5DB42231E191008961AB /* LevelMaskView.swift in Sources */,
-@@ -4071,6 +4090,7 @@
- 				B43D69D62A26642300DF0925 /* DemoPlaceHolderView.swift in Sources */,
- 				E949E38F24B3711E00024DA0 /* InsulinModelInformationView.swift in Sources */,
- 				895FE08B22011F0C00FCF18A /* EmojiInputHeaderView.swift in Sources */,
-+				DDCFC91E2AA9F702003DE656 /* RenameProfileEditor.swift in Sources */,
- 				895FE08322011F0C00FCF18A /* OverrideSelectionFooterView.swift in Sources */,
- 				89AF78C22447E353002B4FCC /* Splat.swift in Sources */,
- 				893C9F8C2447DBD900CD4185 /* CardBuilder.swift in Sources */,
-@@ -4121,9 +4141,11 @@
+@@ -3799,6 +3818,7 @@
+ 				43BA7187201EE7090058961E /* GlucoseRangeScheduleTableViewController.swift in Sources */,
+ 				B46B62AF23FF0BF6001E69BA /* SectionHeader.swift in Sources */,
+ 				43BA7183201EE7090058961E /* DailyQuantityScheduleTableViewController.swift in Sources */,
++				DDEACA2A2AAF797F00E57735 /* RenameProfileEditor.swift in Sources */,
+ 				1D1FCE2324BD13A2000300A8 /* CorrectionRangeOverridesExpandableSetting.swift in Sources */,
+ 				E93BA06624A39DBC00C5D7E6 /* DismissibleHostingController.swift in Sources */,
+ 				43F503632106C761009FA89A /* ServiceAuthenticationUI.swift in Sources */,
+@@ -3812,8 +3832,10 @@
  				E9C58A6E24DA65E400487A17 /* HistoricalOverrideDetailView.swift in Sources */,
  				895FE08222011F0C00FCF18A /* LabeledTextFieldTableViewCell.swift in Sources */,
  				B43DA44224D9CD8500CAFF4E /* Environment+Colors.swift in Sources */,
 +				DD508E062A17712D00EEF8FD /* ProfileViewModel+FileManagement.swift in Sources */,
  				892A5DB22231E191008961AB /* LoadingTableViewCell.swift in Sources */,
  				B4D3D4AD25B8A94E0085BA0F /* DisplayGlucoseUnitObserver.swift in Sources */,
- 				A9D3FF102A6C19CA000C891D /* ChartAxisValueDoubleLog.swift in Sources */,
 +				DD7122612A1D2AA4004FE653 /* ProfilePreviewView.swift in Sources */,
  				E96DCB5A24AF74AC007117BC /* SuspendThresholdEditor.swift in Sources */,
  				E96DCB5824AEF50F007117BC /* SuspendThresholdInformationView.swift in Sources */,
- 				A9D3FF0C2A6C198C000C891D /* CollectionType.swift in Sources */,
-@@ -4199,6 +4221,7 @@
+ 				C140E0522602908A000A4FF7 /* SettingsPresentationMode.swift in Sources */,
+@@ -3880,6 +3902,7 @@
  				E93C86B624D08CAD0073089B /* InsulinSensitivityInformationView.swift in Sources */,
  				C18733AF29B9492300519CDF /* Collection.swift in Sources */,
  				892A5DA22231E137008961AB /* HUDProvider.swift in Sources */,
@@ -167,7 +173,7 @@ index 8354209..f061a30 100644
  				898E6E6C224194060019E459 /* UIColor.swift in Sources */,
  				43BA717D201EE7090058961E /* GlucoseRangeTableViewCell.swift in Sources */,
  				B455F3A425FF7FF0000ED456 /* CorrectionRangeOverridesEditorViewModel.swift in Sources */,
-@@ -4225,6 +4248,7 @@
+@@ -3902,6 +3925,7 @@
  				1D1065E9282DC54700026A70 /* VideoPlayView.swift in Sources */,
  				E99A132E2557548300D3F5B3 /* SegmentedGaugeBar.swift in Sources */,
  				B455F31825FBEC5F000ED456 /* SuspendThresholdEditorViewModel.swift in Sources */,
@@ -177,10 +183,10 @@ index 8354209..f061a30 100644
  				B41A60AF23D1DB5B00636320 /* TableViewTitleLabel.swift in Sources */,
 diff --git a/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
 new file mode 100644
-index 0000000..56dc952
+index 0000000..c4100d5
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
-@@ -0,0 +1,400 @@
+@@ -0,0 +1,389 @@
 +//
 +//  ProfileViewModel+FileManagement.swift
 +//  LoopKitUI
@@ -200,7 +206,7 @@ index 0000000..56dc952
 +    case carbRatioError
 +    case basalRateError
 +    case maxBasalRateNotSet
-+
++    
 +    public var errorDescription: String? {
 +        switch self {
 +        case .fileLoadError:
@@ -249,7 +255,7 @@ index 0000000..56dc952
 +        let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
 +        return documentsDirectory.appendingPathComponent("LoopProfile")
 +    }
-+
++    
 +    private func createProfileDirectoryIfNotExists() throws {
 +        let fileManager = FileManager.default
 +        var isDir : ObjCBool = false
@@ -259,102 +265,91 @@ index 0000000..56dc952
 +            throw NSError(domain: NSCocoaErrorDomain, code: NSFileWriteFileExistsError, userInfo: nil)
 +        }
 +    }
-+
++    
 +    private func getAllProfileFiles() throws -> [URL] {
 +        let fileManager = FileManager.default
 +        let files = try fileManager.contentsOfDirectory(at: profilesDirectory, includingPropertiesForKeys: nil)
 +        return files.filter { $0.pathExtension == "json" }
 +    }
-+
++    
 +    private func encodeProfile(_ profile: Profile) throws -> Data {
 +        return try JSONEncoder().encode(profile)
 +    }
-+
++    
 +    private func decodeProfile(from data: Data) throws -> Profile {
 +        return try JSONDecoder().decode(Profile.self, from: data)
 +    }
-+
-+    public func sanitizeProfileName(_ name: String) -> String {
-+        // Replace problematic characters
-+        var sanitized = name.replacingOccurrences(of: ".", with: "_")
-+        
-+        return sanitized
-+    }
-+
++    
 +    public func saveProfile(withName name: String) {
-+        let sanitizedName = sanitizeProfileName(name)
-+
 +        do {
 +            try createProfileDirectoryIfNotExists()
-+
-+            if let existingProfile = getProfileReference(withName: sanitizedName) {
++            
++            if let existingProfile = getProfileReference(withName: name) {
 +                removeProfile(profileReference: existingProfile)
 +            }
-+
++            
 +            let profile = Profile(
-+                name: sanitizedName,
++                name: name,
 +                correctionRange: (therapySettings.glucoseTargetRangeSchedule?.schedule(for: .milligramsPerDeciliter)!)!,
 +                carbRatioSchedule: therapySettings.carbRatioSchedule!,
 +                basalRateSchedule: therapySettings.basalRateSchedule!,
 +                insulinSensitivitySchedule: (therapySettings.insulinSensitivitySchedule?.schedule(for: .milligramsPerDeciliter)!)!,
 +                sortOrder: -1
 +            )
-+
++            
 +            let jsonData = try encodeProfile(profile)
-+
++            
 +            let dateFormatter = DateFormatter()
 +            dateFormatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
 +            let fileName = dateFormatter.string(from: Date()) + ".json"
 +            let fileURL = profilesDirectory.appendingPathComponent(fileName)
-+
++            
 +            try jsonData.write(to: fileURL)
-+            setCurrentProfile(name: sanitizedName, syncChange: true)
-+
++            setCurrentProfile(name: name, syncChange: true)
++            
 +            self.loadProfiles()
 +        } catch {
 +            print("An error occurred while saving profile: \(error)")
 +        }
 +    }
-+
++    
 +    public func renameProfile(oldName: String, newName: String) {
-+        let sanitizedProfileName = sanitizeProfileName(newName)
-+
 +        if currentProfileName == oldName {
-+            setCurrentProfile(name: sanitizedProfileName, syncChange: true)
++            setCurrentProfile(name: newName, syncChange: true)
 +        }
-+
++        
 +        do {
 +            guard let profileReference = getProfileReference(withName: oldName) else {
 +                print("Profile with old name not found.")
 +                return
 +            }
-+
++            
 +            let profile = try getProfile(from: profileReference)
-+
++            
 +            let newProfile = Profile(
-+                name: sanitizedProfileName,
++                name: newName,
 +                correctionRange: profile.correctionRange,
 +                carbRatioSchedule: profile.carbRatioSchedule,
 +                basalRateSchedule: profile.basalRateSchedule,
 +                insulinSensitivitySchedule: profile.insulinSensitivitySchedule,
 +                sortOrder: profile.sortOrder
 +            )
-+
-+            if let existingProfile = getProfileReference(withName: sanitizedProfileName) {
++            
++            if let existingProfile = getProfileReference(withName: newName) {
 +                removeProfile(profileReference: existingProfile)
 +            }
-+
++            
 +            let jsonData = try encodeProfile(newProfile)
 +            let fileURL = profilesDirectory.appendingPathComponent(profileReference.fileName)
-+
++            
 +            try jsonData.write(to: fileURL)
-+
++            
 +            self.loadProfiles()
 +        } catch {
 +            print("An error occurred while renaming profile: \(error)")
 +        }
 +    }
-+
++    
 +    public func updateProfilesOrder() {
 +        for (index, profileReference) in profiles.enumerated() {
 +            do {
@@ -398,7 +393,7 @@ index 0000000..56dc952
 +            print("An error occurred while loading profiles: \(error)")
 +        }
 +    }
-+
++    
 +    public func loadProfile(profile: Profile, completion: @escaping (LoadProfileResult) -> Void) {
 +        if(therapySettings.glucoseTargetRangeSchedule == profile.correctionRange &&
 +           therapySettings.carbRatioSchedule == profile.carbRatioSchedule &&
@@ -431,23 +426,23 @@ index 0000000..56dc952
 +            }
 +        }
 +    }
-+
++    
 +    func getProfileReference(withName name: String) -> ProfileReference? {
 +        return profiles.first(where: { $0.name == name })
 +    }
-+
++    
 +    public func removeProfile(profile: Profile) {
 +        guard let profileReference = getProfileReference(withName: profile.name) else {
 +            print("No ProfileReference found for given Profile")
 +            return
 +        }
-+
++        
 +        removeProfile(profileReference: profileReference)
 +        if getCurrentProfileName() == profile.name {
 +            clearCurrentProfile()
 +        }
 +    }
-+
++    
 +    public func removeProfile(profileReference: ProfileReference) {
 +        do {
 +            let fileManager = FileManager.default
@@ -458,56 +453,56 @@ index 0000000..56dc952
 +            print("An error occurred while removing profile: \(error)")
 +        }
 +    }
-+
++    
 +    func doesProfileExist(withName name: String) -> Bool {
 +        return profiles.contains(where: { $0.name == name })
 +    }
-+
++    
 +    public func getProfile(from profileReference: ProfileReference) throws -> Profile {
 +        let fileURL = profilesDirectory.appendingPathComponent(profileReference.fileName)
 +        let data = try Data(contentsOf: fileURL)
 +        let getProfile = try decodeProfile(from: data)
 +        return getProfile
 +    }
-+
++    
 +    public func validateProfile(_ profile: Profile) -> Result<Void, ProfileValidationError> {
 +        guard let supportedIncrements = delegate?.pumpSupportedIncrements() else {
 +            return .failure(.fileLoadError)
 +        }
-+
++        
 +        // Checking Correction Range Schedule
 +        for item in profile.correctionRange.items {
 +            let minValue = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: item.value.minValue)
 +            let maxValue = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: item.value.maxValue)
-+
++            
 +            if !(Guardrail.correctionRange.absoluteBounds.contains(minValue) && Guardrail.correctionRange.absoluteBounds.contains(maxValue)) {
 +                return .failure(.correctionRangeError)
 +            }
 +        }
-+
++        
 +        // Checking Insulin Sensitivity Schedule
 +        for item in profile.insulinSensitivitySchedule.items {
 +            let value = HKQuantity(unit: HKUnit.milligramsPerDeciliter.unitDivided(by: .internationalUnit()), doubleValue: item.value)
-+
++            
 +            if !Guardrail.insulinSensitivity.absoluteBounds.contains(value) {
 +                return .failure(.insulinSensitivityError)
 +            }
 +        }
-+
++        
 +        // Checking Carb Ratio Schedule
 +        for item in profile.carbRatioSchedule.items {
 +            let value = HKQuantity(unit: .gramsPerUnit, doubleValue: item.value)
-+
++            
 +            if !Guardrail.carbRatio.absoluteBounds.contains(value) {
 +                return .failure(.carbRatioError)
 +            }
 +        }
-+
++        
 +        // Checking Basal Rate Schedule
 +        if let maximumBasalRate = therapySettings.maximumBasalRatePerHour {
 +            for item in profile.basalRateSchedule.items {
 +                let value = item.value
-+
++                
 +                if value > maximumBasalRate || !supportedIncrements.basalRates.contains(value) {
 +                    return .failure(.basalRateError)
 +                }
@@ -515,10 +510,10 @@ index 0000000..56dc952
 +        } else {
 +            return .failure(.maxBasalRateNotSet)
 +        }
-+
++        
 +        return .success(())
 +    }
-+
++    
 +    func isCorrectionRangeEqual(a: GlucoseRangeSchedule, b: GlucoseRangeSchedule) -> Bool {
 +        guard a.items.count == b.items.count else {
 +            return false
@@ -583,7 +578,7 @@ index 0000000..56dc952
 +}
 diff --git a/LoopKit/LoopKitUI/ViewModels/ProfileViewModel.swift b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel.swift
 new file mode 100644
-index 0000000..a48fa66
+index 0000000..2c6b870
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel.swift
 @@ -0,0 +1,86 @@
@@ -610,7 +605,7 @@ index 0000000..a48fa66
 +            UserDefaults.standard.setValue(currentProfileName, forKey: "currentProfileName")
 +        }
 +    }
-+
++    
 +    internal weak var delegate: TherapySettingsViewModelDelegate?
 +    
 +    public init(therapySettings: TherapySettings,
@@ -668,13 +663,13 @@ index 0000000..a48fa66
 +        therapySettings.insulinSensitivitySchedule = insulinSensitivitySchedule
 +        delegate?.saveCompletion(therapySettings: therapySettings)
 +    }
-+
++    
 +    public func triggerProfileSync() {
 +        delegate?.updateCurrentProfileName()
 +    }
 +}
 diff --git a/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift b/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
-index 3650ef6..c5c1dc0 100644
+index 3650ef6..956bc7e 100644
 --- a/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
 +++ b/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
 @@ -16,6 +16,7 @@ public protocol TherapySettingsViewModelDelegate: AnyObject {
@@ -685,9 +680,56 @@ index 3650ef6..c5c1dc0 100644
  }
  
  public class TherapySettingsViewModel: ObservableObject {
+@@ -110,16 +111,16 @@ extension TherapySettingsViewModel {
+         therapySettings.glucoseTargetRangeSchedule = range
+         delegate?.saveCompletion(therapySettings: therapySettings)
+     }
+-        
++    
+     public func saveCorrectionRangeOverride(preset: CorrectionRangeOverrides.Preset,
+                                             correctionRangeOverrides: CorrectionRangeOverrides) {
+         therapySettings.correctionRangeOverrides = correctionRangeOverrides
+         delegate?.saveCompletion(therapySettings: therapySettings)
+     }
+-
++    
+     public func saveSuspendThreshold(quantity: HKQuantity, withDisplayGlucoseUnit displayGlucoseUnit: HKUnit) {
+         therapySettings.suspendThreshold = GlucoseThreshold(unit: displayGlucoseUnit, value: quantity.doubleValue(for: displayGlucoseUnit))
+-
++        
+         // TODO: Eventually target editors should support conflicting initial values
+         // But for now, ensure target ranges do not conflict with suspend threshold.
+         if let targetSchedule = therapySettings.glucoseTargetRangeSchedule {
+@@ -133,7 +134,7 @@ extension TherapySettingsViewModel {
+             }
+             therapySettings.glucoseTargetRangeSchedule = GlucoseRangeSchedule(unit: targetSchedule.unit, dailyItems: newItems)
+         }
+-
++        
+         if let overrides = therapySettings.correctionRangeOverrides {
+             let adjusted = [overrides.preMeal, overrides.workout].map { item -> ClosedRange<HKQuantity>? in
+                 guard let item = item else {
+@@ -148,7 +149,7 @@ extension TherapySettingsViewModel {
+                 preMeal: adjusted[0],
+                 workout: adjusted[1])
+         }
+-
++        
+         if let presets = therapySettings.overridePresets {
+             therapySettings.overridePresets = presets.map { preset in
+                 if let targetRange = preset.settings.targetRange {
+@@ -165,7 +166,7 @@ extension TherapySettingsViewModel {
+                 }
+             }
+         }
+-
++        
+         delegate?.saveCompletion(therapySettings: therapySettings)
+     }
+     
 diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/NewProfileEditor.swift b/LoopKit/LoopKitUI/Views/Settings Editors/NewProfileEditor.swift
 new file mode 100644
-index 0000000..446910e
+index 0000000..4fcbea1
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/Views/Settings Editors/NewProfileEditor.swift	
 @@ -0,0 +1,79 @@
@@ -707,7 +749,7 @@ index 0000000..446910e
 +    @State var newProfileName: String
 +    var viewModel: ProfileViewModel
 +    @State private var showAlert = false
-+
++    
 +    var body: some View {
 +        VStack(spacing: 0) {
 +            ModalHeaderButtonBar(
@@ -718,7 +760,7 @@ index 0000000..446910e
 +                },
 +                trailing: { addButton }
 +            )
-+
++            
 +            TextField("Profile Name", text: $newProfileName)
 +                .textFieldStyle(RoundedBorderTextFieldStyle())
 +                .padding()
@@ -740,7 +782,7 @@ index 0000000..446910e
 +            )
 +        }
 +    }
-+
++    
 +    var addButton: some View {
 +        Button(
 +            action: {
@@ -757,7 +799,7 @@ index 0000000..446910e
 +            }
 +        )
 +    }
-+
++    
 +    var cancelButton: some View {
 +        Button(
 +            action: {
@@ -772,7 +814,7 @@ index 0000000..446910e
 +}
 diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/ProfilePreviewView.swift b/LoopKit/LoopKitUI/Views/Settings Editors/ProfilePreviewView.swift
 new file mode 100644
-index 0000000..6de3598
+index 0000000..abe31ad
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/Views/Settings Editors/ProfilePreviewView.swift	
 @@ -0,0 +1,326 @@
@@ -796,21 +838,21 @@ index 0000000..6de3598
 +}
 +
 +struct ProfilePreviewView: View {
-+    @EnvironmentObject private var displayGlucosePreference: DisplayGlucosePreference
++    @EnvironmentObject private var displayGlucoseUnitObservable: DisplayGlucoseUnitObservable
 +    @ObservedObject var viewModel: ProfileViewModel
 +    @Environment(\.dismissAction) var dismissAction
 +    @Environment(\.presentationMode) var presentationMode
 +    var profile: Profile
-+
++    
 +    @State private var showingAlert = false
 +    @State private var activeAlert: ActiveAlert = .load
 +    @State private var errorText: String?
 +    @State private var newProfileName: String = ""
 +    @State private var isRenamingProfile = false
 +    @State private var shouldDismissSelf: Bool = false
-+
++    
 +    let nilDestination: (_ dismiss: @escaping () -> Void) -> AnyView = { _ in AnyView(EmptyView()) }
-+
++    
 +    var body: some View {
 +        ZStack {
 +            ScrollView {
@@ -951,18 +993,18 @@ index 0000000..6de3598
 +            }
 +        }
 +    }
-+
++    
 +    private var profileCardStack: CardStack {
 +        var cards: [Card] = []
-+
++        
 +        cards.append(correctionRangeSection)
 +        cards.append(carbRatioSection)
 +        cards.append(basalRatesSection)
 +        cards.append(insulinSensitivitiesSection)
-+
++        
 +        return CardStack(cards: cards)
 +    }
-+
++    
 +    private var correctionRangeSection: Card {
 +        card(for: .glucoseTargetRange) {
 +            if let items = profile.correctionRange.schedule(for: glucoseUnit)?.items {
@@ -971,7 +1013,7 @@ index 0000000..6de3598
 +                    if index > 0 {
 +                        SettingsDivider()
 +                    }
-+
++                    
 +                    ScheduleRangeItem(time: items[index].startTime,
 +                                      range: items[index].value,
 +                                      unit: glucoseUnit,
@@ -980,7 +1022,7 @@ index 0000000..6de3598
 +            }
 +        }
 +    }
-+
++    
 +    private var carbRatioSection: Card {
 +        card(for: .carbRatio) {
 +            SectionDivider()
@@ -989,7 +1031,7 @@ index 0000000..6de3598
 +                if index > 0 {
 +                    SettingsDivider()
 +                }
-+
++                
 +                ScheduleValueItem(time: items[index].startTime,
 +                                  value: items[index].value,
 +                                  unit: .gramsPerUnit,
@@ -997,7 +1039,7 @@ index 0000000..6de3598
 +            }
 +        }
 +    }
-+
++    
 +    private var basalRatesSection: Card {
 +        card(for: .basalRate) {
 +            let items = profile.basalRateSchedule.items
@@ -1009,7 +1051,7 @@ index 0000000..6de3598
 +                    if index > 0 {
 +                        SettingsDivider()
 +                    }
-+
++                    
 +                    ScheduleValueItem(time: items[index].startTime,
 +                                      value:  items[index].value,
 +                                      unit: .internationalUnitsPerHour,
@@ -1028,7 +1070,7 @@ index 0000000..6de3598
 +            }
 +        }
 +    }
-+
++    
 +    private var insulinSensitivitiesSection: Card {
 +        card(for: .insulinSensitivity) {
 +            if let items = profile.insulinSensitivitySchedule.schedule(for: glucoseUnit)?.items
@@ -1052,14 +1094,14 @@ index 0000000..6de3598
 +struct SectionWithContent<Content>: View where Content: View {
 +    let title: String
 +    let content: Content
-+
++    
 +    init(title: String,
 +         content: () -> Content)
 +    {
 +        self.title = title
 +        self.content = content()
 +    }
-+
++    
 +    public var body: some View {
 +        Section {
 +            Text(title)
@@ -1072,15 +1114,15 @@ index 0000000..6de3598
 +
 +// MARK: Utilities
 +extension ProfilePreviewView {
-+
++    
 +    private var glucoseUnit: HKUnit {
-+        displayGlucosePreference.unit
++        displayGlucoseUnitObservable.displayGlucoseUnit
 +    }
 +
 +    private var sensitivityUnit: HKUnit {
 +        glucoseUnit.unitDivided(by: .internationalUnit())
 +    }
-+
++    
 +    private func card<Content>(for therapySetting: TherapySetting, @ViewBuilder content: @escaping () -> Content) -> Card where Content: View {
 +        Card {
 +            SectionWithContent(title: therapySetting.title,
@@ -1104,7 +1146,7 @@ index 0000000..6de3598
 +}
 diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/ProfileView.swift b/LoopKit/LoopKitUI/Views/Settings Editors/ProfileView.swift
 new file mode 100644
-index 0000000..1c6244a
+index 0000000..de24519
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/Views/Settings Editors/ProfileView.swift	
 @@ -0,0 +1,173 @@
@@ -1129,7 +1171,7 @@ index 0000000..1c6244a
 +    @State private var isAddingNewProfile = false
 +    @State private var selectedProfileIndex: Int? = nil
 +    @State private var refreshID = UUID()
-+
++    
 +    enum ActiveAlert: String, Identifiable {
 +        case update, info
 +        
@@ -1283,7 +1325,7 @@ index 0000000..1c6244a
 +}
 diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/RenameProfileEditor.swift b/LoopKit/LoopKitUI/Views/Settings Editors/RenameProfileEditor.swift
 new file mode 100644
-index 0000000..8fd2666
+index 0000000..e53775a
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/Views/Settings Editors/RenameProfileEditor.swift	
 @@ -0,0 +1,92 @@
@@ -1305,7 +1347,7 @@ index 0000000..8fd2666
 +    var viewModel: ProfileViewModel
 +    @State private var showAlert = false
 +    @Binding var shouldDismissParent: Bool
-+
++    
 +    var body: some View {
 +        VStack(spacing: 0) {
 +            ModalHeaderButtonBar(
@@ -1313,7 +1355,7 @@ index 0000000..8fd2666
 +                center: {
 +                    Text("Rename Profile")
 +                        .font(.subheadline)
-+
++                    
 +                },
 +                trailing: { renameButton }
 +            )
@@ -1352,7 +1394,7 @@ index 0000000..8fd2666
 +                        self.isPresented = false
 +                        return
 +                    }
-+
++                    
 +                    if viewModel.doesProfileExist(withName: self.newProfileName) {
 +                        self.showAlert = true
 +                    } else {
@@ -1379,38 +1421,40 @@ index 0000000..8fd2666
 +        )
 +    }
 +}
-Submodule LoopOnboarding 4c5c192..e15f085:
+Submodule LoopOnboarding 308097a..6c615ac:
 diff --git a/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift b/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift
-index cc61f2d..6462e2c 100644
+index 079d59e..013e482 100644
 --- a/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift	
 +++ b/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift	
 @@ -379,6 +379,9 @@ extension OnboardingUICoordinator: TherapySettingsViewModelDelegate {
              maximumBasalScheduleEntryCount: maximumBasalScheduleEntryCount
          )
      }
-+    
++
 +    func updateCurrentProfileName() {
 +    }
  }
  
  
-Submodule NightscoutService 9b2f2ae..2093122:
+Submodule NightscoutService 1196d9e..5036131:
 diff --git a/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift b/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift
-index 0bed9c6..7d6c12d 100644
+index 0bed9c6..49c1f52 100644
 --- a/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift
 +++ b/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift
-@@ -94,12 +94,20 @@ extension StoredSettings {
+@@ -93,13 +93,21 @@ extension StoredSettings {
+         guard let bloodGlucoseUnit = bloodGlucoseUnit, let profile = profile, let loopSettings = loopSettings else {
              return nil
          }
- 
+-
++        
 +        var store = ["Default": profile]
 +        var defaultProfile = "Default"
-+
++        
 +        if let name = UserDefaults.standard.string(forKey: "currentProfileName") {
 +            defaultProfile = name
 +            store[name] = profile
 +        }
-+
++        
          return ProfileSet(
              startDate: date,
              units: bloodGlucoseUnit.shortLocalizedUnitString(avoidLineBreaking: false),

--- a/2002/dev_2002.patch
+++ b/2002/dev_2002.patch
@@ -177,10 +177,10 @@ index 8354209..f061a30 100644
  				B41A60AF23D1DB5B00636320 /* TableViewTitleLabel.swift in Sources */,
 diff --git a/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
 new file mode 100644
-index 0000000..56dc952
+index 0000000..6d9e370
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
-@@ -0,0 +1,400 @@
+@@ -0,0 +1,402 @@
 +//
 +//  ProfileViewModel+FileManagement.swift
 +//  LoopKitUI
@@ -229,8 +229,9 @@ index 0000000..56dc952
 +// MARK: File management
 +extension ProfileViewModel {
 +    private func setCurrentProfile(name: String, syncChange: Bool = false) {
-+        currentProfileName = name
-+        if (syncChange) {
++        let sanitizedProfileName = sanitizeProfileName(name)
++        currentProfileName = sanitizedProfileName
++        if syncChange {
 +            triggerProfileSync()
 +        }
 +    }
@@ -277,7 +278,7 @@ index 0000000..56dc952
 +    public func sanitizeProfileName(_ name: String) -> String {
 +        // Replace problematic characters
 +        var sanitized = name.replacingOccurrences(of: ".", with: "_")
-+        
++
 +        return sanitized
 +    }
 +
@@ -322,15 +323,15 @@ index 0000000..56dc952
 +        if currentProfileName == oldName {
 +            setCurrentProfile(name: sanitizedProfileName, syncChange: true)
 +        }
-+
++        
 +        do {
 +            guard let profileReference = getProfileReference(withName: oldName) else {
 +                print("Profile with old name not found.")
 +                return
 +            }
-+
++            
 +            let profile = try getProfile(from: profileReference)
-+
++            
 +            let newProfile = Profile(
 +                name: sanitizedProfileName,
 +                correctionRange: profile.correctionRange,
@@ -339,16 +340,16 @@ index 0000000..56dc952
 +                insulinSensitivitySchedule: profile.insulinSensitivitySchedule,
 +                sortOrder: profile.sortOrder
 +            )
-+
++            
 +            if let existingProfile = getProfileReference(withName: sanitizedProfileName) {
 +                removeProfile(profileReference: existingProfile)
 +            }
-+
++            
 +            let jsonData = try encodeProfile(newProfile)
 +            let fileURL = profilesDirectory.appendingPathComponent(profileReference.fileName)
-+
++            
 +            try jsonData.write(to: fileURL)
-+
++            
 +            self.loadProfiles()
 +        } catch {
 +            print("An error occurred while renaming profile: \(error)")
@@ -387,7 +388,7 @@ index 0000000..56dc952
 +            for fileURL in profileFiles {
 +                let data = try Data(contentsOf: fileURL)
 +                let profile = try decodeProfile(from: data)
-+                let profileRef = ProfileReference(name: profile.name, fileName: fileURL.lastPathComponent, sortOrder: profile.sortOrder)
++                let profileRef = ProfileReference(name: sanitizeProfileName(profile.name), fileName: fileURL.lastPathComponent, sortOrder: profile.sortOrder)
 +                newProfiles.append(profileRef)
 +            }
 +            
@@ -433,7 +434,8 @@ index 0000000..56dc952
 +    }
 +
 +    func getProfileReference(withName name: String) -> ProfileReference? {
-+        return profiles.first(where: { $0.name == name })
++        let sanitizedInputName = sanitizeProfileName(name)
++        return profiles.first(where: { sanitizeProfileName($0.name) == sanitizedInputName })
 +    }
 +
 +    public func removeProfile(profile: Profile) {

--- a/2002/main_2002.patch
+++ b/2002/main_2002.patch
@@ -82,6 +82,7 @@ index 8fca5668..1b7828c8 100644
              ForEach(configurationMenuItemsForSupportPlugins) { item in
                  item.view
              }
+Submodule LoopKit contains modified content
 Submodule LoopKit 9835a29..8a58d2e:
 diff --git a/LoopKit/LoopKit.xcodeproj/project.pbxproj b/LoopKit/LoopKit.xcodeproj/project.pbxproj
 index 6b13fc8..c6bcc64 100644
@@ -183,10 +184,10 @@ index 6b13fc8..c6bcc64 100644
  				B41A60AF23D1DB5B00636320 /* TableViewTitleLabel.swift in Sources */,
 diff --git a/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
 new file mode 100644
-index 0000000..c4100d5
+index 0000000..a7b2571
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
-@@ -0,0 +1,389 @@
+@@ -0,0 +1,400 @@
 +//
 +//  ProfileViewModel+FileManagement.swift
 +//  LoopKitUI
@@ -280,16 +281,25 @@ index 0000000..c4100d5
 +        return try JSONDecoder().decode(Profile.self, from: data)
 +    }
 +    
++    public func sanitizeProfileName(_ name: String) -> String {
++        // Replace problematic characters
++        var sanitized = name.replacingOccurrences(of: ".", with: "_")
++        
++        return sanitized
++    }
++    
 +    public func saveProfile(withName name: String) {
++        let sanitizedName = sanitizeProfileName(name)
++
 +        do {
 +            try createProfileDirectoryIfNotExists()
 +            
-+            if let existingProfile = getProfileReference(withName: name) {
++            if let existingProfile = getProfileReference(withName: sanitizedName) {
 +                removeProfile(profileReference: existingProfile)
 +            }
 +            
 +            let profile = Profile(
-+                name: name,
++                name: sanitizedName,
 +                correctionRange: (therapySettings.glucoseTargetRangeSchedule?.schedule(for: .milligramsPerDeciliter)!)!,
 +                carbRatioSchedule: therapySettings.carbRatioSchedule!,
 +                basalRateSchedule: therapySettings.basalRateSchedule!,
@@ -305,7 +315,7 @@ index 0000000..c4100d5
 +            let fileURL = profilesDirectory.appendingPathComponent(fileName)
 +            
 +            try jsonData.write(to: fileURL)
-+            setCurrentProfile(name: name, syncChange: true)
++            setCurrentProfile(name: sanitizedName, syncChange: true)
 +            
 +            self.loadProfiles()
 +        } catch {
@@ -314,8 +324,10 @@ index 0000000..c4100d5
 +    }
 +    
 +    public func renameProfile(oldName: String, newName: String) {
++        let sanitizedProfileName = sanitizeProfileName(newName)
++
 +        if currentProfileName == oldName {
-+            setCurrentProfile(name: newName, syncChange: true)
++            setCurrentProfile(name: sanitizedProfileName, syncChange: true)
 +        }
 +        
 +        do {
@@ -327,7 +339,7 @@ index 0000000..c4100d5
 +            let profile = try getProfile(from: profileReference)
 +            
 +            let newProfile = Profile(
-+                name: newName,
++                name: sanitizedProfileName,
 +                correctionRange: profile.correctionRange,
 +                carbRatioSchedule: profile.carbRatioSchedule,
 +                basalRateSchedule: profile.basalRateSchedule,
@@ -335,7 +347,7 @@ index 0000000..c4100d5
 +                sortOrder: profile.sortOrder
 +            )
 +            
-+            if let existingProfile = getProfileReference(withName: newName) {
++            if let existingProfile = getProfileReference(withName: sanitizedProfileName) {
 +                removeProfile(profileReference: existingProfile)
 +            }
 +            

--- a/2002/main_2002.patch
+++ b/2002/main_2002.patch
@@ -184,10 +184,10 @@ index 6b13fc8..c6bcc64 100644
  				B41A60AF23D1DB5B00636320 /* TableViewTitleLabel.swift in Sources */,
 diff --git a/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
 new file mode 100644
-index 0000000..a7b2571
+index 0000000..c18c25f
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
-@@ -0,0 +1,400 @@
+@@ -0,0 +1,402 @@
 +//
 +//  ProfileViewModel+FileManagement.swift
 +//  LoopKitUI
@@ -236,8 +236,9 @@ index 0000000..a7b2571
 +// MARK: File management
 +extension ProfileViewModel {
 +    private func setCurrentProfile(name: String, syncChange: Bool = false) {
-+        currentProfileName = name
-+        if (syncChange) {
++        let sanitizedProfileName = sanitizeProfileName(name)
++        currentProfileName = sanitizedProfileName
++        if syncChange {
 +            triggerProfileSync()
 +        }
 +    }
@@ -394,7 +395,7 @@ index 0000000..a7b2571
 +            for fileURL in profileFiles {
 +                let data = try Data(contentsOf: fileURL)
 +                let profile = try decodeProfile(from: data)
-+                let profileRef = ProfileReference(name: profile.name, fileName: fileURL.lastPathComponent, sortOrder: profile.sortOrder)
++                let profileRef = ProfileReference(name: sanitizeProfileName(profile.name), fileName: fileURL.lastPathComponent, sortOrder: profile.sortOrder)
 +                newProfiles.append(profileRef)
 +            }
 +            
@@ -440,7 +441,8 @@ index 0000000..a7b2571
 +    }
 +    
 +    func getProfileReference(withName name: String) -> ProfileReference? {
-+        return profiles.first(where: { $0.name == name })
++        let sanitizedInputName = sanitizeProfileName(name)
++        return profiles.first(where: { sanitizeProfileName($0.name) == sanitizedInputName })
 +    }
 +    
 +    public func removeProfile(profile: Profile) {


### PR DESCRIPTION
We've identified a critical issue in the Nightscout integration (up to version 15.0.2), where uploading a profile through the API with a name containing a "." character leads to a crash. This PR addresses this problem by introducing a fix that automatically replaces any "." in profile names with "_".

The solution is implemented through a new function, sanitizedName, designed for modifying profile names. This function is currently focused on replacing the "." character, but it's structured for easy extension. Should we encounter other problematic characters in the future, we can readily add them to this function's replacement logic.

This change ensures greater stability in our interactions with the Nightscout API and prevents potential crashes due to profile naming issues.