### PR TITLE
Extend sanitizeProfileName to replace '<' and limit to 32 chars

### DIFF
--- a/2002/archive/2024-01-20-dev_2002.patch
+++ b/2002/archive/2024-01-20-dev_2002.patch
@@ -1,9 +1,9 @@
-Submodule Loop c6b058b..df945eb:
+Submodule Loop b6610a1..6e6b0f2:
 diff --git a/Loop/Loop/Managers/DeviceDataManager.swift b/Loop/Loop/Managers/DeviceDataManager.swift
-index 4e1cbfdf..30de494f 100644
+index 2751f18f..4866c85c 100644
 --- a/Loop/Loop/Managers/DeviceDataManager.swift
 +++ b/Loop/Loop/Managers/DeviceDataManager.swift
-@@ -1754,6 +1754,10 @@ extension DeviceDataManager: TherapySettingsViewModelDelegate {
+@@ -1636,6 +1636,10 @@ extension DeviceDataManager: TherapySettingsViewModelDelegate {
          }
      }
      
@@ -15,7 +15,7 @@ index 4e1cbfdf..30de494f 100644
  
          loopManager.mutateSettings { settings in
 diff --git a/Loop/Loop/Managers/LoopDataManager.swift b/Loop/Loop/Managers/LoopDataManager.swift
-index 18a08166..8f1f44c6 100644
+index 2319f4ec..63164e69 100644
 --- a/Loop/Loop/Managers/LoopDataManager.swift
 +++ b/Loop/Loop/Managers/LoopDataManager.swift
 @@ -229,6 +229,10 @@ final class LoopDataManager {
@@ -30,65 +30,57 @@ index 18a08166..8f1f44c6 100644
          var oldValue: LoopSettings!
          let newValue = lockedSettings.mutate { settings in
 diff --git a/Loop/Loop/Views/SettingsView.swift b/Loop/Loop/Views/SettingsView.swift
-index 8fca5668..1b7828c8 100644
+index c3ec98b8..74045900 100644
 --- a/Loop/Loop/Views/SettingsView.swift
 +++ b/Loop/Loop/Views/SettingsView.swift
-@@ -24,6 +24,7 @@ public struct SettingsView: View {
-     @ObservedObject var viewModel: SettingsViewModel
-     @ObservedObject var versionUpdateViewModel: VersionUpdateViewModel
- 
-+    @State private var profilesIsPresented: Bool = false
-     @State private var pumpChooserIsPresented: Bool = false
-     @State private var cgmChooserIsPresented: Bool = false
-     @State private var serviceChooserIsPresented: Bool = false
-@@ -150,7 +151,11 @@ extension SettingsView {
-             }
+@@ -51,6 +51,7 @@ public struct SettingsView: View {
+             
+             case favoriteFoods
+             case therapySettings
++            case profiles
          }
      }
--        
-+
-+    private var isAnySheetPresented: Bool {
-+        therapySettingsIsPresented || profilesIsPresented
-+    }
-+
-     private var configurationSection: some View {
-         Section(header: SectionHeader(label: NSLocalizedString("Configuration", comment: "The title of the Configuration section in settings"))) {
-             LargeButton(action: { self.therapySettingsIsPresented = true },
-@@ -173,7 +178,26 @@ extension SettingsView {
-                         .environment(\.guidanceColors, self.guidanceColors)
-                         .environment(\.insulinTintColor, self.insulinTintColor)
+     
+@@ -157,6 +158,19 @@ public struct SettingsView: View {
+                     .environment(\.insulinTintColor, self.insulinTintColor)
+                 case .favoriteFoods:
+                     FavoriteFoodsView()
++                case .profiles:
++                    ProfileView(viewModel: ProfileViewModel(therapySettings: self.viewModel.therapySettings(),
++                                                            sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
++                                                            adultChildInsulinModelSelectionEnabled: FeatureFlags.adultChildInsulinModelSelectionEnabled,
++                                                            delegate: self.viewModel.therapySettingsViewModelDelegate))
++                    .environmentObject(displayGlucosePreference)
++                    .environment(\.dismissAction, self.dismiss)
++                    .environment(\.appName, self.appName)
++                    .environment(\.chartColorPalette, .primary)
++                    .environment(\.carbTintColor, self.carbTintColor)
++                    .environment(\.glucoseTintColor, self.glucoseTintColor)
++                    .environment(\.guidanceColors, self.guidanceColors)
++                    .environment(\.insulinTintColor, self.insulinTintColor)
+                 }
              }
+         }
+@@ -294,7 +308,11 @@ extension SettingsView {
+                             imageView: Image("Therapy Icon"),
+                             label: NSLocalizedString("Therapy Settings", comment: "Title text for button to Therapy Settings"),
+                             descriptiveText: NSLocalizedString("Diabetes Treatment", comment: "Descriptive text for Therapy Settings"))
 -            
-+            LargeButton(action: { self.profilesIsPresented = true },
++            LargeButton(action: { sheet = .profiles },
 +                        includeArrow: true,
 +                        imageView: AnyView(Image(systemName: "arrow.triangle.2.circlepath").font(.system(size: 30, weight: .bold))),
 +                        label: NSLocalizedString("Profiles", comment: "Title text for button to Profiles"),
 +                        descriptiveText: NSLocalizedString("Switch between profiles for different scenarios", comment: "Descriptive text for Profiles"))
-+            .sheet(isPresented: $profilesIsPresented) {
-+                ProfileView(viewModel: ProfileViewModel(therapySettings: self.viewModel.therapySettings(),
-+                                                        sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
-+                                                        adultChildInsulinModelSelectionEnabled: FeatureFlags.adultChildInsulinModelSelectionEnabled,
-+                                                        delegate: self.viewModel.therapySettingsViewModelDelegate))
-+                .environmentObject(displayGlucoseUnitObservable)
-+                .environment(\.dismissAction, self.dismiss)
-+                .environment(\.appName, self.appName)
-+                .environment(\.chartColorPalette, .primary)
-+                .environment(\.carbTintColor, self.carbTintColor)
-+                .environment(\.glucoseTintColor, self.glucoseTintColor)
-+                .environment(\.guidanceColors, self.guidanceColors)
-+                .environment(\.insulinTintColor, self.insulinTintColor)
-+            }
-+
-             ForEach(configurationMenuItemsForSupportPlugins) { item in
+             ForEach(pluginMenuItems.filter {$0.section == .configuration}) { item in
                  item.view
              }
 Submodule LoopKit contains modified content
-Submodule LoopKit 9835a29..8a58d2e:
+Submodule LoopKit 70d1860..4e09f44:
 diff --git a/LoopKit/LoopKit.xcodeproj/project.pbxproj b/LoopKit/LoopKit.xcodeproj/project.pbxproj
-index 6b13fc8..c6bcc64 100644
+index 8354209..f061a30 100644
 --- a/LoopKit/LoopKit.xcodeproj/project.pbxproj
 +++ b/LoopKit/LoopKit.xcodeproj/project.pbxproj
-@@ -787,6 +787,12 @@
+@@ -864,6 +864,12 @@
  		C1FAEC1D264AD6B400A3250B /* DeviceStatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FAEC1C264AD6B400A3250B /* DeviceStatusBadge.swift */; };
  		C1FAEC1F264AE12700A3250B /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47ECF8725DC20810024A54D /* UIImage.swift */; };
  		C1FAEC21264AEEA300A3250B /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FAEC20264AEEA300A3250B /* UIImage.swift */; };
@@ -97,11 +89,11 @@ index 6b13fc8..c6bcc64 100644
 +		DD7122612A1D2AA4004FE653 /* ProfilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7122602A1D2AA4004FE653 /* ProfilePreviewView.swift */; };
 +		DDAF746729F422C600719F0A /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAF746629F422C600719F0A /* ProfileView.swift */; };
 +		DDAF746929F4234000719F0A /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAF746829F4234000719F0A /* ProfileViewModel.swift */; };
-+		DDEACA2A2AAF797F00E57735 /* RenameProfileEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEACA292AAF797F00E57735 /* RenameProfileEditor.swift */; };
++		DDCFC91E2AA9F702003DE656 /* RenameProfileEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCFC91D2AA9F702003DE656 /* RenameProfileEditor.swift */; };
  		E9077D2724ACD59F0066A88D /* InformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9077D2624ACD59F0066A88D /* InformationView.swift */; };
  		E9077D2A24ACDE2C0066A88D /* CorrectionRangeInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9077D2924ACDE2C0066A88D /* CorrectionRangeInformationView.swift */; };
  		E9086B2924B39EDC0062F5C8 /* ChartsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B2824B39EDC0062F5C8 /* ChartsTableViewController.swift */; };
-@@ -1763,6 +1769,12 @@
+@@ -1923,6 +1929,12 @@
  		C1FDCC0A29C786F90056E652 /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/Localizable.strings; sourceTree = "<group>"; };
  		C1FDCC0B29C786F90056E652 /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/Localizable.strings; sourceTree = "<group>"; };
  		C1FF3D4E29C786A900BDC1EC /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -110,17 +102,17 @@ index 6b13fc8..c6bcc64 100644
 +		DD7122602A1D2AA4004FE653 /* ProfilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePreviewView.swift; sourceTree = "<group>"; };
 +		DDAF746629F422C600719F0A /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 +		DDAF746829F4234000719F0A /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
-+		DDEACA292AAF797F00E57735 /* RenameProfileEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameProfileEditor.swift; sourceTree = "<group>"; };
++		DDCFC91D2AA9F702003DE656 /* RenameProfileEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameProfileEditor.swift; sourceTree = "<group>"; };
  		E9077D2624ACD59F0066A88D /* InformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationView.swift; sourceTree = "<group>"; };
  		E9077D2924ACDE2C0066A88D /* CorrectionRangeInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeInformationView.swift; sourceTree = "<group>"; };
  		E9086B2824B39EDC0062F5C8 /* ChartsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartsTableViewController.swift; sourceTree = "<group>"; };
-@@ -2942,11 +2954,13 @@
+@@ -3167,11 +3179,13 @@
  			isa = PBXGroup;
  			children = (
  				B455F3A325FF7FF0000ED456 /* CorrectionRangeOverridesEditorViewModel.swift */,
 +				DDAF746829F4234000719F0A /* ProfileViewModel.swift */,
  				B4B7C1BB2604E3FC007379F6 /* CorrectionRangeScheduleEditorViewModel.swift */,
- 				B4D4C20C25F95A8700DA809D /* DisplayGlucoseUnitObservable.swift */,
+ 				B4D4C20C25F95A8700DA809D /* DisplayGlucosePreference.swift */,
  				B455F48025FF9A8B000ED456 /* InsulinSensitivityScheduleEditorViewModel.swift */,
  				B455F2A125FBE985000ED456 /* SuspendThresholdEditorViewModel.swift */,
  				1D1FCE2424BD42EF000300A8 /* TherapySettingsViewModel.swift */,
@@ -128,18 +120,18 @@ index 6b13fc8..c6bcc64 100644
  			);
  			path = ViewModels;
  			sourceTree = "<group>";
-@@ -3077,6 +3091,10 @@
+@@ -3358,6 +3372,10 @@
  				E96DCB5924AF74AC007117BC /* SuspendThresholdEditor.swift */,
  				1D1FCE2A24BE704A000300A8 /* TherapySetting+Settings.swift */,
  				1D1A019D24B678BF0077D86E /* TherapySettingsView.swift */,
 +				DDAF746629F422C600719F0A /* ProfileView.swift */,
 +				DD508E072A17763700EEF8FD /* NewProfileEditor.swift */,
 +				DD7122602A1D2AA4004FE653 /* ProfilePreviewView.swift */,
-+				DDEACA292AAF797F00E57735 /* RenameProfileEditor.swift */,
++				DDCFC91D2AA9F702003DE656 /* RenameProfileEditor.swift */,
  			);
  			path = "Settings Editors";
  			sourceTree = "<group>";
-@@ -3757,6 +3775,7 @@
+@@ -4062,6 +4080,7 @@
  				E9086B4824B5405E0062F5C8 /* ChartAxisValueDoubleUnit.swift in Sources */,
  				B429D66C24BF7204003E1B4A /* GlucoseTrend.swift in Sources */,
  				432CF86720D76AB90066B889 /* SettingsTableViewCell.swift in Sources */,
@@ -147,26 +139,27 @@ index 6b13fc8..c6bcc64 100644
  				898B4E7B246DC6A70053C484 /* CorrectionRangeScheduleEditor.swift in Sources */,
  				E9E5E56A24D5CCE800B5DFFE /* OverrideViewCell.swift in Sources */,
  				892A5DB42231E191008961AB /* LevelMaskView.swift in Sources */,
-@@ -3799,6 +3818,7 @@
- 				43BA7187201EE7090058961E /* GlucoseRangeScheduleTableViewController.swift in Sources */,
- 				B46B62AF23FF0BF6001E69BA /* SectionHeader.swift in Sources */,
- 				43BA7183201EE7090058961E /* DailyQuantityScheduleTableViewController.swift in Sources */,
-+				DDEACA2A2AAF797F00E57735 /* RenameProfileEditor.swift in Sources */,
- 				1D1FCE2324BD13A2000300A8 /* CorrectionRangeOverridesExpandableSetting.swift in Sources */,
- 				E93BA06624A39DBC00C5D7E6 /* DismissibleHostingController.swift in Sources */,
- 				43F503632106C761009FA89A /* ServiceAuthenticationUI.swift in Sources */,
-@@ -3812,8 +3832,10 @@
+@@ -4071,6 +4090,7 @@
+ 				B43D69D62A26642300DF0925 /* DemoPlaceHolderView.swift in Sources */,
+ 				E949E38F24B3711E00024DA0 /* InsulinModelInformationView.swift in Sources */,
+ 				895FE08B22011F0C00FCF18A /* EmojiInputHeaderView.swift in Sources */,
++				DDCFC91E2AA9F702003DE656 /* RenameProfileEditor.swift in Sources */,
+ 				895FE08322011F0C00FCF18A /* OverrideSelectionFooterView.swift in Sources */,
+ 				89AF78C22447E353002B4FCC /* Splat.swift in Sources */,
+ 				893C9F8C2447DBD900CD4185 /* CardBuilder.swift in Sources */,
+@@ -4121,9 +4141,11 @@
  				E9C58A6E24DA65E400487A17 /* HistoricalOverrideDetailView.swift in Sources */,
  				895FE08222011F0C00FCF18A /* LabeledTextFieldTableViewCell.swift in Sources */,
  				B43DA44224D9CD8500CAFF4E /* Environment+Colors.swift in Sources */,
 +				DD508E062A17712D00EEF8FD /* ProfileViewModel+FileManagement.swift in Sources */,
  				892A5DB22231E191008961AB /* LoadingTableViewCell.swift in Sources */,
  				B4D3D4AD25B8A94E0085BA0F /* DisplayGlucoseUnitObserver.swift in Sources */,
+ 				A9D3FF102A6C19CA000C891D /* ChartAxisValueDoubleLog.swift in Sources */,
 +				DD7122612A1D2AA4004FE653 /* ProfilePreviewView.swift in Sources */,
  				E96DCB5A24AF74AC007117BC /* SuspendThresholdEditor.swift in Sources */,
  				E96DCB5824AEF50F007117BC /* SuspendThresholdInformationView.swift in Sources */,
- 				C140E0522602908A000A4FF7 /* SettingsPresentationMode.swift in Sources */,
-@@ -3880,6 +3902,7 @@
+ 				A9D3FF0C2A6C198C000C891D /* CollectionType.swift in Sources */,
+@@ -4199,6 +4221,7 @@
  				E93C86B624D08CAD0073089B /* InsulinSensitivityInformationView.swift in Sources */,
  				C18733AF29B9492300519CDF /* Collection.swift in Sources */,
  				892A5DA22231E137008961AB /* HUDProvider.swift in Sources */,
@@ -174,7 +167,7 @@ index 6b13fc8..c6bcc64 100644
  				898E6E6C224194060019E459 /* UIColor.swift in Sources */,
  				43BA717D201EE7090058961E /* GlucoseRangeTableViewCell.swift in Sources */,
  				B455F3A425FF7FF0000ED456 /* CorrectionRangeOverridesEditorViewModel.swift in Sources */,
-@@ -3902,6 +3925,7 @@
+@@ -4225,6 +4248,7 @@
  				1D1065E9282DC54700026A70 /* VideoPlayView.swift in Sources */,
  				E99A132E2557548300D3F5B3 /* SegmentedGaugeBar.swift in Sources */,
  				B455F31825FBEC5F000ED456 /* SuspendThresholdEditorViewModel.swift in Sources */,
@@ -184,10 +177,10 @@ index 6b13fc8..c6bcc64 100644
  				B41A60AF23D1DB5B00636320 /* TableViewTitleLabel.swift in Sources */,
 diff --git a/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
 new file mode 100644
-index 0000000..81a2c3d
+index 0000000..6d9e370
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
-@@ -0,0 +1,408 @@
+@@ -0,0 +1,402 @@
 +//
 +//  ProfileViewModel+FileManagement.swift
 +//  LoopKitUI
@@ -207,7 +200,7 @@ index 0000000..81a2c3d
 +    case carbRatioError
 +    case basalRateError
 +    case maxBasalRateNotSet
-+    
++
 +    public var errorDescription: String? {
 +        switch self {
 +        case .fileLoadError:
@@ -257,7 +250,7 @@ index 0000000..81a2c3d
 +        let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
 +        return documentsDirectory.appendingPathComponent("LoopProfile")
 +    }
-+    
++
 +    private func createProfileDirectoryIfNotExists() throws {
 +        let fileManager = FileManager.default
 +        var isDir : ObjCBool = false
@@ -267,30 +260,24 @@ index 0000000..81a2c3d
 +            throw NSError(domain: NSCocoaErrorDomain, code: NSFileWriteFileExistsError, userInfo: nil)
 +        }
 +    }
-+    
++
 +    private func getAllProfileFiles() throws -> [URL] {
 +        let fileManager = FileManager.default
 +        let files = try fileManager.contentsOfDirectory(at: profilesDirectory, includingPropertiesForKeys: nil)
 +        return files.filter { $0.pathExtension == "json" }
 +    }
-+    
++
 +    private func encodeProfile(_ profile: Profile) throws -> Data {
 +        return try JSONEncoder().encode(profile)
 +    }
-+    
++
 +    private func decodeProfile(from data: Data) throws -> Profile {
 +        return try JSONDecoder().decode(Profile.self, from: data)
 +    }
-+    
++
 +    public func sanitizeProfileName(_ name: String) -> String {
 +        // Replace problematic characters
 +        var sanitized = name.replacingOccurrences(of: ".", with: "_")
-+        sanitized = sanitized.replacingOccurrences(of: "<", with: "_")
-+
-+        // Limit the name to 32 characters
-+        if sanitized.count > 32 {
-+            sanitized = String(sanitized.prefix(32))
-+        }
 +
 +        return sanitized
 +    }
@@ -300,11 +287,11 @@ index 0000000..81a2c3d
 +
 +        do {
 +            try createProfileDirectoryIfNotExists()
-+            
++
 +            if let existingProfile = getProfileReference(withName: sanitizedName) {
 +                removeProfile(profileReference: existingProfile)
 +            }
-+            
++
 +            let profile = Profile(
 +                name: sanitizedName,
 +                correctionRange: (therapySettings.glucoseTargetRangeSchedule?.schedule(for: .milligramsPerDeciliter)!)!,
@@ -313,23 +300,23 @@ index 0000000..81a2c3d
 +                insulinSensitivitySchedule: (therapySettings.insulinSensitivitySchedule?.schedule(for: .milligramsPerDeciliter)!)!,
 +                sortOrder: -1
 +            )
-+            
++
 +            let jsonData = try encodeProfile(profile)
-+            
++
 +            let dateFormatter = DateFormatter()
 +            dateFormatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
 +            let fileName = dateFormatter.string(from: Date()) + ".json"
 +            let fileURL = profilesDirectory.appendingPathComponent(fileName)
-+            
++
 +            try jsonData.write(to: fileURL)
 +            setCurrentProfile(name: sanitizedName, syncChange: true)
-+            
++
 +            self.loadProfiles()
 +        } catch {
 +            print("An error occurred while saving profile: \(error)")
 +        }
 +    }
-+    
++
 +    public func renameProfile(oldName: String, newName: String) {
 +        let sanitizedProfileName = sanitizeProfileName(newName)
 +
@@ -368,7 +355,7 @@ index 0000000..81a2c3d
 +            print("An error occurred while renaming profile: \(error)")
 +        }
 +    }
-+    
++
 +    public func updateProfilesOrder() {
 +        for (index, profileReference) in profiles.enumerated() {
 +            do {
@@ -412,7 +399,7 @@ index 0000000..81a2c3d
 +            print("An error occurred while loading profiles: \(error)")
 +        }
 +    }
-+    
++
 +    public func loadProfile(profile: Profile, completion: @escaping (LoadProfileResult) -> Void) {
 +        if(therapySettings.glucoseTargetRangeSchedule == profile.correctionRange &&
 +           therapySettings.carbRatioSchedule == profile.carbRatioSchedule &&
@@ -445,24 +432,24 @@ index 0000000..81a2c3d
 +            }
 +        }
 +    }
-+    
++
 +    func getProfileReference(withName name: String) -> ProfileReference? {
 +        let sanitizedInputName = sanitizeProfileName(name)
 +        return profiles.first(where: { sanitizeProfileName($0.name) == sanitizedInputName })
 +    }
-+    
++
 +    public func removeProfile(profile: Profile) {
 +        guard let profileReference = getProfileReference(withName: profile.name) else {
 +            print("No ProfileReference found for given Profile")
 +            return
 +        }
-+        
++
 +        removeProfile(profileReference: profileReference)
 +        if getCurrentProfileName() == profile.name {
 +            clearCurrentProfile()
 +        }
 +    }
-+    
++
 +    public func removeProfile(profileReference: ProfileReference) {
 +        do {
 +            let fileManager = FileManager.default
@@ -473,56 +460,56 @@ index 0000000..81a2c3d
 +            print("An error occurred while removing profile: \(error)")
 +        }
 +    }
-+    
++
 +    func doesProfileExist(withName name: String) -> Bool {
 +        return profiles.contains(where: { $0.name == name })
 +    }
-+    
++
 +    public func getProfile(from profileReference: ProfileReference) throws -> Profile {
 +        let fileURL = profilesDirectory.appendingPathComponent(profileReference.fileName)
 +        let data = try Data(contentsOf: fileURL)
 +        let getProfile = try decodeProfile(from: data)
 +        return getProfile
 +    }
-+    
++
 +    public func validateProfile(_ profile: Profile) -> Result<Void, ProfileValidationError> {
 +        guard let supportedIncrements = delegate?.pumpSupportedIncrements() else {
 +            return .failure(.fileLoadError)
 +        }
-+        
++
 +        // Checking Correction Range Schedule
 +        for item in profile.correctionRange.items {
 +            let minValue = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: item.value.minValue)
 +            let maxValue = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: item.value.maxValue)
-+            
++
 +            if !(Guardrail.correctionRange.absoluteBounds.contains(minValue) && Guardrail.correctionRange.absoluteBounds.contains(maxValue)) {
 +                return .failure(.correctionRangeError)
 +            }
 +        }
-+        
++
 +        // Checking Insulin Sensitivity Schedule
 +        for item in profile.insulinSensitivitySchedule.items {
 +            let value = HKQuantity(unit: HKUnit.milligramsPerDeciliter.unitDivided(by: .internationalUnit()), doubleValue: item.value)
-+            
++
 +            if !Guardrail.insulinSensitivity.absoluteBounds.contains(value) {
 +                return .failure(.insulinSensitivityError)
 +            }
 +        }
-+        
++
 +        // Checking Carb Ratio Schedule
 +        for item in profile.carbRatioSchedule.items {
 +            let value = HKQuantity(unit: .gramsPerUnit, doubleValue: item.value)
-+            
++
 +            if !Guardrail.carbRatio.absoluteBounds.contains(value) {
 +                return .failure(.carbRatioError)
 +            }
 +        }
-+        
++
 +        // Checking Basal Rate Schedule
 +        if let maximumBasalRate = therapySettings.maximumBasalRatePerHour {
 +            for item in profile.basalRateSchedule.items {
 +                let value = item.value
-+                
++
 +                if value > maximumBasalRate || !supportedIncrements.basalRates.contains(value) {
 +                    return .failure(.basalRateError)
 +                }
@@ -530,10 +517,10 @@ index 0000000..81a2c3d
 +        } else {
 +            return .failure(.maxBasalRateNotSet)
 +        }
-+        
++
 +        return .success(())
 +    }
-+    
++
 +    func isCorrectionRangeEqual(a: GlucoseRangeSchedule, b: GlucoseRangeSchedule) -> Bool {
 +        guard a.items.count == b.items.count else {
 +            return false
@@ -598,7 +585,7 @@ index 0000000..81a2c3d
 +}
 diff --git a/LoopKit/LoopKitUI/ViewModels/ProfileViewModel.swift b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel.swift
 new file mode 100644
-index 0000000..2c6b870
+index 0000000..a48fa66
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel.swift
 @@ -0,0 +1,86 @@
@@ -625,7 +612,7 @@ index 0000000..2c6b870
 +            UserDefaults.standard.setValue(currentProfileName, forKey: "currentProfileName")
 +        }
 +    }
-+    
++
 +    internal weak var delegate: TherapySettingsViewModelDelegate?
 +    
 +    public init(therapySettings: TherapySettings,
@@ -683,13 +670,13 @@ index 0000000..2c6b870
 +        therapySettings.insulinSensitivitySchedule = insulinSensitivitySchedule
 +        delegate?.saveCompletion(therapySettings: therapySettings)
 +    }
-+    
++
 +    public func triggerProfileSync() {
 +        delegate?.updateCurrentProfileName()
 +    }
 +}
 diff --git a/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift b/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
-index 3650ef6..956bc7e 100644
+index 3650ef6..c5c1dc0 100644
 --- a/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
 +++ b/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
 @@ -16,6 +16,7 @@ public protocol TherapySettingsViewModelDelegate: AnyObject {
@@ -700,56 +687,9 @@ index 3650ef6..956bc7e 100644
  }
  
  public class TherapySettingsViewModel: ObservableObject {
-@@ -110,16 +111,16 @@ extension TherapySettingsViewModel {
-         therapySettings.glucoseTargetRangeSchedule = range
-         delegate?.saveCompletion(therapySettings: therapySettings)
-     }
--        
-+    
-     public func saveCorrectionRangeOverride(preset: CorrectionRangeOverrides.Preset,
-                                             correctionRangeOverrides: CorrectionRangeOverrides) {
-         therapySettings.correctionRangeOverrides = correctionRangeOverrides
-         delegate?.saveCompletion(therapySettings: therapySettings)
-     }
--
-+    
-     public func saveSuspendThreshold(quantity: HKQuantity, withDisplayGlucoseUnit displayGlucoseUnit: HKUnit) {
-         therapySettings.suspendThreshold = GlucoseThreshold(unit: displayGlucoseUnit, value: quantity.doubleValue(for: displayGlucoseUnit))
--
-+        
-         // TODO: Eventually target editors should support conflicting initial values
-         // But for now, ensure target ranges do not conflict with suspend threshold.
-         if let targetSchedule = therapySettings.glucoseTargetRangeSchedule {
-@@ -133,7 +134,7 @@ extension TherapySettingsViewModel {
-             }
-             therapySettings.glucoseTargetRangeSchedule = GlucoseRangeSchedule(unit: targetSchedule.unit, dailyItems: newItems)
-         }
--
-+        
-         if let overrides = therapySettings.correctionRangeOverrides {
-             let adjusted = [overrides.preMeal, overrides.workout].map { item -> ClosedRange<HKQuantity>? in
-                 guard let item = item else {
-@@ -148,7 +149,7 @@ extension TherapySettingsViewModel {
-                 preMeal: adjusted[0],
-                 workout: adjusted[1])
-         }
--
-+        
-         if let presets = therapySettings.overridePresets {
-             therapySettings.overridePresets = presets.map { preset in
-                 if let targetRange = preset.settings.targetRange {
-@@ -165,7 +166,7 @@ extension TherapySettingsViewModel {
-                 }
-             }
-         }
--
-+        
-         delegate?.saveCompletion(therapySettings: therapySettings)
-     }
-     
 diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/NewProfileEditor.swift b/LoopKit/LoopKitUI/Views/Settings Editors/NewProfileEditor.swift
 new file mode 100644
-index 0000000..4fcbea1
+index 0000000..446910e
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/Views/Settings Editors/NewProfileEditor.swift	
 @@ -0,0 +1,79 @@
@@ -769,7 +709,7 @@ index 0000000..4fcbea1
 +    @State var newProfileName: String
 +    var viewModel: ProfileViewModel
 +    @State private var showAlert = false
-+    
++
 +    var body: some View {
 +        VStack(spacing: 0) {
 +            ModalHeaderButtonBar(
@@ -780,7 +720,7 @@ index 0000000..4fcbea1
 +                },
 +                trailing: { addButton }
 +            )
-+            
++
 +            TextField("Profile Name", text: $newProfileName)
 +                .textFieldStyle(RoundedBorderTextFieldStyle())
 +                .padding()
@@ -802,7 +742,7 @@ index 0000000..4fcbea1
 +            )
 +        }
 +    }
-+    
++
 +    var addButton: some View {
 +        Button(
 +            action: {
@@ -819,7 +759,7 @@ index 0000000..4fcbea1
 +            }
 +        )
 +    }
-+    
++
 +    var cancelButton: some View {
 +        Button(
 +            action: {
@@ -834,7 +774,7 @@ index 0000000..4fcbea1
 +}
 diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/ProfilePreviewView.swift b/LoopKit/LoopKitUI/Views/Settings Editors/ProfilePreviewView.swift
 new file mode 100644
-index 0000000..abe31ad
+index 0000000..6de3598
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/Views/Settings Editors/ProfilePreviewView.swift	
 @@ -0,0 +1,326 @@
@@ -858,21 +798,21 @@ index 0000000..abe31ad
 +}
 +
 +struct ProfilePreviewView: View {
-+    @EnvironmentObject private var displayGlucoseUnitObservable: DisplayGlucoseUnitObservable
++    @EnvironmentObject private var displayGlucosePreference: DisplayGlucosePreference
 +    @ObservedObject var viewModel: ProfileViewModel
 +    @Environment(\.dismissAction) var dismissAction
 +    @Environment(\.presentationMode) var presentationMode
 +    var profile: Profile
-+    
++
 +    @State private var showingAlert = false
 +    @State private var activeAlert: ActiveAlert = .load
 +    @State private var errorText: String?
 +    @State private var newProfileName: String = ""
 +    @State private var isRenamingProfile = false
 +    @State private var shouldDismissSelf: Bool = false
-+    
++
 +    let nilDestination: (_ dismiss: @escaping () -> Void) -> AnyView = { _ in AnyView(EmptyView()) }
-+    
++
 +    var body: some View {
 +        ZStack {
 +            ScrollView {
@@ -1013,18 +953,18 @@ index 0000000..abe31ad
 +            }
 +        }
 +    }
-+    
++
 +    private var profileCardStack: CardStack {
 +        var cards: [Card] = []
-+        
++
 +        cards.append(correctionRangeSection)
 +        cards.append(carbRatioSection)
 +        cards.append(basalRatesSection)
 +        cards.append(insulinSensitivitiesSection)
-+        
++
 +        return CardStack(cards: cards)
 +    }
-+    
++
 +    private var correctionRangeSection: Card {
 +        card(for: .glucoseTargetRange) {
 +            if let items = profile.correctionRange.schedule(for: glucoseUnit)?.items {
@@ -1033,7 +973,7 @@ index 0000000..abe31ad
 +                    if index > 0 {
 +                        SettingsDivider()
 +                    }
-+                    
++
 +                    ScheduleRangeItem(time: items[index].startTime,
 +                                      range: items[index].value,
 +                                      unit: glucoseUnit,
@@ -1042,7 +982,7 @@ index 0000000..abe31ad
 +            }
 +        }
 +    }
-+    
++
 +    private var carbRatioSection: Card {
 +        card(for: .carbRatio) {
 +            SectionDivider()
@@ -1051,7 +991,7 @@ index 0000000..abe31ad
 +                if index > 0 {
 +                    SettingsDivider()
 +                }
-+                
++
 +                ScheduleValueItem(time: items[index].startTime,
 +                                  value: items[index].value,
 +                                  unit: .gramsPerUnit,
@@ -1059,7 +999,7 @@ index 0000000..abe31ad
 +            }
 +        }
 +    }
-+    
++
 +    private var basalRatesSection: Card {
 +        card(for: .basalRate) {
 +            let items = profile.basalRateSchedule.items
@@ -1071,7 +1011,7 @@ index 0000000..abe31ad
 +                    if index > 0 {
 +                        SettingsDivider()
 +                    }
-+                    
++
 +                    ScheduleValueItem(time: items[index].startTime,
 +                                      value:  items[index].value,
 +                                      unit: .internationalUnitsPerHour,
@@ -1090,7 +1030,7 @@ index 0000000..abe31ad
 +            }
 +        }
 +    }
-+    
++
 +    private var insulinSensitivitiesSection: Card {
 +        card(for: .insulinSensitivity) {
 +            if let items = profile.insulinSensitivitySchedule.schedule(for: glucoseUnit)?.items
@@ -1114,14 +1054,14 @@ index 0000000..abe31ad
 +struct SectionWithContent<Content>: View where Content: View {
 +    let title: String
 +    let content: Content
-+    
++
 +    init(title: String,
 +         content: () -> Content)
 +    {
 +        self.title = title
 +        self.content = content()
 +    }
-+    
++
 +    public var body: some View {
 +        Section {
 +            Text(title)
@@ -1134,15 +1074,15 @@ index 0000000..abe31ad
 +
 +// MARK: Utilities
 +extension ProfilePreviewView {
-+    
++
 +    private var glucoseUnit: HKUnit {
-+        displayGlucoseUnitObservable.displayGlucoseUnit
++        displayGlucosePreference.unit
 +    }
 +
 +    private var sensitivityUnit: HKUnit {
 +        glucoseUnit.unitDivided(by: .internationalUnit())
 +    }
-+    
++
 +    private func card<Content>(for therapySetting: TherapySetting, @ViewBuilder content: @escaping () -> Content) -> Card where Content: View {
 +        Card {
 +            SectionWithContent(title: therapySetting.title,
@@ -1166,7 +1106,7 @@ index 0000000..abe31ad
 +}
 diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/ProfileView.swift b/LoopKit/LoopKitUI/Views/Settings Editors/ProfileView.swift
 new file mode 100644
-index 0000000..de24519
+index 0000000..1c6244a
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/Views/Settings Editors/ProfileView.swift	
 @@ -0,0 +1,173 @@
@@ -1191,7 +1131,7 @@ index 0000000..de24519
 +    @State private var isAddingNewProfile = false
 +    @State private var selectedProfileIndex: Int? = nil
 +    @State private var refreshID = UUID()
-+    
++
 +    enum ActiveAlert: String, Identifiable {
 +        case update, info
 +        
@@ -1345,7 +1285,7 @@ index 0000000..de24519
 +}
 diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/RenameProfileEditor.swift b/LoopKit/LoopKitUI/Views/Settings Editors/RenameProfileEditor.swift
 new file mode 100644
-index 0000000..e53775a
+index 0000000..8fd2666
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/Views/Settings Editors/RenameProfileEditor.swift	
 @@ -0,0 +1,92 @@
@@ -1367,7 +1307,7 @@ index 0000000..e53775a
 +    var viewModel: ProfileViewModel
 +    @State private var showAlert = false
 +    @Binding var shouldDismissParent: Bool
-+    
++
 +    var body: some View {
 +        VStack(spacing: 0) {
 +            ModalHeaderButtonBar(
@@ -1375,7 +1315,7 @@ index 0000000..e53775a
 +                center: {
 +                    Text("Rename Profile")
 +                        .font(.subheadline)
-+                    
++
 +                },
 +                trailing: { renameButton }
 +            )
@@ -1414,7 +1354,7 @@ index 0000000..e53775a
 +                        self.isPresented = false
 +                        return
 +                    }
-+                    
++
 +                    if viewModel.doesProfileExist(withName: self.newProfileName) {
 +                        self.showAlert = true
 +                    } else {
@@ -1441,40 +1381,38 @@ index 0000000..e53775a
 +        )
 +    }
 +}
-Submodule LoopOnboarding 308097a..6c615ac:
+Submodule LoopOnboarding 4c5c192..e15f085:
 diff --git a/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift b/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift
-index 079d59e..013e482 100644
+index cc61f2d..6462e2c 100644
 --- a/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift	
 +++ b/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift	
 @@ -379,6 +379,9 @@ extension OnboardingUICoordinator: TherapySettingsViewModelDelegate {
              maximumBasalScheduleEntryCount: maximumBasalScheduleEntryCount
          )
      }
-+
++    
 +    func updateCurrentProfileName() {
 +    }
  }
  
  
-Submodule NightscoutService 1196d9e..5036131:
+Submodule NightscoutService 9b2f2ae..2093122:
 diff --git a/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift b/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift
-index 0bed9c6..49c1f52 100644
+index 0bed9c6..7d6c12d 100644
 --- a/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift
 +++ b/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift
-@@ -93,13 +93,21 @@ extension StoredSettings {
-         guard let bloodGlucoseUnit = bloodGlucoseUnit, let profile = profile, let loopSettings = loopSettings else {
+@@ -94,12 +94,20 @@ extension StoredSettings {
              return nil
          }
--
-+        
+ 
 +        var store = ["Default": profile]
 +        var defaultProfile = "Default"
-+        
++
 +        if let name = UserDefaults.standard.string(forKey: "currentProfileName") {
 +            defaultProfile = name
 +            store[name] = profile
 +        }
-+        
++
          return ProfileSet(
              startDate: date,
              units: bloodGlucoseUnit.shortLocalizedUnitString(avoidLineBreaking: false),

--- a/2002/archive/2024-01-20-main_2002.patch
+++ b/2002/archive/2024-01-20-main_2002.patch
@@ -184,10 +184,10 @@ index 6b13fc8..c6bcc64 100644
  				B41A60AF23D1DB5B00636320 /* TableViewTitleLabel.swift in Sources */,
 diff --git a/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
 new file mode 100644
-index 0000000..81a2c3d
+index 0000000..c18c25f
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
-@@ -0,0 +1,408 @@
+@@ -0,0 +1,402 @@
 +//
 +//  ProfileViewModel+FileManagement.swift
 +//  LoopKitUI
@@ -285,16 +285,10 @@ index 0000000..81a2c3d
 +    public func sanitizeProfileName(_ name: String) -> String {
 +        // Replace problematic characters
 +        var sanitized = name.replacingOccurrences(of: ".", with: "_")
-+        sanitized = sanitized.replacingOccurrences(of: "<", with: "_")
-+
-+        // Limit the name to 32 characters
-+        if sanitized.count > 32 {
-+            sanitized = String(sanitized.prefix(32))
-+        }
-+
++        
 +        return sanitized
 +    }
-+
++    
 +    public func saveProfile(withName name: String) {
 +        let sanitizedName = sanitizeProfileName(name)
 +

--- a/2002/dev_2002.patch
+++ b/2002/dev_2002.patch
@@ -177,10 +177,10 @@ index 8354209..f061a30 100644
  				B41A60AF23D1DB5B00636320 /* TableViewTitleLabel.swift in Sources */,
 diff --git a/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
 new file mode 100644
-index 0000000..6d9e370
+index 0000000..74724fb
 --- /dev/null
 +++ b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
-@@ -0,0 +1,402 @@
+@@ -0,0 +1,408 @@
 +//
 +//  ProfileViewModel+FileManagement.swift
 +//  LoopKitUI
@@ -278,6 +278,12 @@ index 0000000..6d9e370
 +    public func sanitizeProfileName(_ name: String) -> String {
 +        // Replace problematic characters
 +        var sanitized = name.replacingOccurrences(of: ".", with: "_")
++        sanitized = sanitized.replacingOccurrences(of: "<", with: "_")
++
++        // Limit the name to 32 characters
++        if sanitized.count > 32 {
++            sanitized = String(sanitized.prefix(32))
++        }
 +
 +        return sanitized
 +    }


### PR DESCRIPTION
This PR enhances the sanitizeProfileName function. Changes include:

1. Adding functionality to replace the '<' character with an underscore.
2. Limiting profile names to a maximum of 32 characters.

These updates ensure compatibility with external systems (like Nightscout) and improve the robustness of profile name handling.