### PR TITLE
Display a week of meals

### DIFF
--- a/meal_week/archive/meal_week_before_variable_rename.patch
+++ b/meal_week/archive/meal_week_before_variable_rename.patch
@@ -21,7 +21,7 @@ index fc770192..0b85b4c2 100644
  
          let midnight = Calendar.current.startOfDay(for: Date())
 -        let listStart = min(midnight, chartStartDate, Date(timeIntervalSinceNow: -deviceManager.carbStore.maximumAbsorptionTimeInterval))
-+        let earliestMidnight = midnight - .hours(6*24)
++        let previousMidnight = midnight - .hours(6*24)
  
          let reloadGroup = DispatchGroup()
          let shouldUpdateGlucose = currentContext.contains(.glucose)
@@ -30,8 +30,8 @@ index fc770192..0b85b4c2 100644
                  insulinCounteractionEffects = allInsulinCounteractionEffects.filterDateRange(chartStartDate, nil)
  
 +                let earliestCounteractionEffect = allInsulinCounteractionEffects.first?.startDate ?? Date()
-+                // Show carb entries back through midnight a week ago, or only as far back as counteraction effects are available
-+                let boundOnCarbList = max(earliestMidnight, earliestCounteractionEffect)
++                // Show carb entries as far back as previous midnight, or only as far back as counteraction effects are available
++                let boundOnCarbList = max(previousMidnight, earliestCounteractionEffect)
 +                // If counteraction effects are missing, at least show all the entries for today and those on the chart
 +                let displayListStart = min(boundOnCarbList, midnight, chartStartDate)
 +                // To estimate dynamic carb absorption for the entry at the start of the list, we need to fetch samples that might still be absorbing

--- a/meal_week/meal_week.patch
+++ b/meal_week/meal_week.patch
@@ -1,0 +1,89 @@
+Submodule Loop contains modified content
+diff --git a/Loop/Loop/Managers/LoopDataManager.swift b/Loop/Loop/Managers/LoopDataManager.swift
+index 2319f4ec..920ad2f9 100644
+--- a/Loop/Loop/Managers/LoopDataManager.swift
++++ b/Loop/Loop/Managers/LoopDataManager.swift
+@@ -992,7 +992,7 @@ extension LoopDataManager {
+ 
+         let retrospectiveStart = lastGlucoseDate.addingTimeInterval(-type(of: retrospectiveCorrection).retrospectionInterval)
+ 
+-        let earliestEffectDate = Date(timeInterval: .hours(-24), since: now())
++        let earliestEffectDate = Date(timeInterval: .hours(-7*24), since: now())
+         let nextCounteractionEffectDate = insulinCounteractionEffects.last?.endDate ?? earliestEffectDate
+         let insulinEffectStartDate = nextCounteractionEffectDate.addingTimeInterval(.minutes(-5))
+ 
+diff --git a/Loop/Loop/View Controllers/CarbAbsorptionViewController.swift b/Loop/Loop/View Controllers/CarbAbsorptionViewController.swift
+index fc770192..0b85b4c2 100644
+--- a/Loop/Loop/View Controllers/CarbAbsorptionViewController.swift	
++++ b/Loop/Loop/View Controllers/CarbAbsorptionViewController.swift	
+@@ -139,7 +139,7 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
+         charts.updateEndDate(chartStartDate.addingTimeInterval(.hours(totalHours+1))) // When there is no data, this allows presenting current hour + 1
+ 
+         let midnight = Calendar.current.startOfDay(for: Date())
+-        let listStart = min(midnight, chartStartDate, Date(timeIntervalSinceNow: -deviceManager.carbStore.maximumAbsorptionTimeInterval))
++        let previousMidnight = midnight - .hours(6*24)
+ 
+         let reloadGroup = DispatchGroup()
+         let shouldUpdateGlucose = currentContext.contains(.glucose)
+@@ -158,11 +158,19 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
+                 let allInsulinCounteractionEffects = state.insulinCounteractionEffects
+                 insulinCounteractionEffects = allInsulinCounteractionEffects.filterDateRange(chartStartDate, nil)
+ 
++                let earliestCounteractionEffect = allInsulinCounteractionEffects.first?.startDate ?? Date()
++                // Show carb entries as far back as previous midnight, or only as far back as counteraction effects are available
++                let boundOnCarbList = max(previousMidnight, earliestCounteractionEffect)
++                // If counteraction effects are missing, at least show all the entries for today and those on the chart
++                let displayListStart = min(boundOnCarbList, midnight, chartStartDate)
++                // To estimate dynamic carb absorption for the entry at the start of the list, we need to fetch samples that might still be absorbing
++                let fetchEntriesStart = displayListStart.addingTimeInterval(-self.deviceManager.carbStore.maximumAbsorptionTimeInterval)
++
+                 reloadGroup.enter()
+-                self.deviceManager.carbStore.getCarbStatus(start: listStart, end: nil, effectVelocities: allInsulinCounteractionEffects) { (result) in
++                self.deviceManager.carbStore.getCarbStatus(start: fetchEntriesStart, end: nil, effectVelocities: allInsulinCounteractionEffects) { (result) in
+                     switch result {
+                     case .success(let status):
+-                        carbStatuses = status
++                        carbStatuses = status.filterDateRange(displayListStart, nil)
+                         carbsOnBoard = status.getClampedCarbsOnBoard()
+                     case .failure(let error):
+                         self.log.error("CarbStore failed to get carbStatus: %{public}@", String(describing: error))
+@@ -173,7 +181,7 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
+                 }
+ 
+                 reloadGroup.enter()
+-                self.deviceManager.carbStore.getGlucoseEffects(start: chartStartDate, end: nil, effectVelocities: insulinCounteractionEffects!) { (result) in
++                self.deviceManager.carbStore.getGlucoseEffects(start: chartStartDate, end: nil, effectVelocities: allInsulinCounteractionEffects) { (result) in
+                     switch result {
+                     case .success((_, let effects)):
+                         carbEffects = effects
+@@ -287,6 +295,14 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
+         return formatter
+     }()
+ 
++    private lazy var relativeTimeFormatter: DateFormatter = {
++        let formatter = DateFormatter()
++        formatter.dateStyle = .medium
++        formatter.doesRelativeDateFormatting = true
++        formatter.timeStyle = .short
++        return formatter
++    }()
++
+     override func numberOfSections(in tableView: UITableView) -> Int {
+         return Section.count
+     }
+@@ -343,7 +359,14 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
+             }
+ 
+             // Entry time
+-            let startTime = timeFormatter.string(from: status.entry.startDate)
++            let startTime: String
++            // Indicate if an entry is from the previous day to avoid potential confusion
++            let midnight = Calendar.current.startOfDay(for: Date())
++            if status.entry.startDate < midnight {
++                startTime = relativeTimeFormatter.string(from: status.entry.startDate)
++            } else {
++                startTime = timeFormatter.string(from: status.entry.startDate)
++            }
+             if  let absorptionTime = status.entry.absorptionTime,
+                 let duration = absorptionFormatter.string(from: absorptionTime)
+             {


### PR DESCRIPTION
Provide an entire week of ICE (meal) display.

This customization is based on 
* Loop PR 2163, [Use full ICE history for displaying estimated carbohydrate effects](https://github.com/LoopKit/Loop/pull/2163#top)
* Loop PR 2182, [Display the previous day's carb entries on the carb absorption screen.](https://github.com/LoopKit/Loop/pull/2182/files#top)
* PR 2182 was modified for a full week instead of 48 hours.

The test method while in the feature branch is found in the lnl-script PR 62: [Display a week of meals](https://github.com/loopandlearn/lnl-scripts/pull/62#top)
