### PR TITLE
add patch that shows 2 days of meals

### DIFF
--- a/meal_days/meal_days.patch
+++ b/meal_days/meal_days.patch
@@ -1,0 +1,89 @@
+Submodule Loop contains modified content
+diff --git a/Loop/Loop/Managers/LoopDataManager.swift b/Loop/Loop/Managers/LoopDataManager.swift
+index 2319f4ec..920ad2f9 100644
+--- a/Loop/Loop/Managers/LoopDataManager.swift
++++ b/Loop/Loop/Managers/LoopDataManager.swift
+@@ -992,7 +992,7 @@ extension LoopDataManager {
+ 
+         let retrospectiveStart = lastGlucoseDate.addingTimeInterval(-type(of: retrospectiveCorrection).retrospectionInterval)
+ 
+-        let earliestEffectDate = Date(timeInterval: .hours(-24), since: now())
++        let earliestEffectDate = Date(timeInterval: .hours(-2*24), since: now())
+         let nextCounteractionEffectDate = insulinCounteractionEffects.last?.endDate ?? earliestEffectDate
+         let insulinEffectStartDate = nextCounteractionEffectDate.addingTimeInterval(.minutes(-5))
+ 
+diff --git a/Loop/Loop/View Controllers/CarbAbsorptionViewController.swift b/Loop/Loop/View Controllers/CarbAbsorptionViewController.swift
+index fc770192..0b85b4c2 100644
+--- a/Loop/Loop/View Controllers/CarbAbsorptionViewController.swift	
++++ b/Loop/Loop/View Controllers/CarbAbsorptionViewController.swift	
+@@ -139,7 +139,7 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
+         charts.updateEndDate(chartStartDate.addingTimeInterval(.hours(totalHours+1))) // When there is no data, this allows presenting current hour + 1
+ 
+         let midnight = Calendar.current.startOfDay(for: Date())
+-        let listStart = min(midnight, chartStartDate, Date(timeIntervalSinceNow: -deviceManager.carbStore.maximumAbsorptionTimeInterval))
++        let earliestMidnight = midnight - .hours(1*24)
+ 
+         let reloadGroup = DispatchGroup()
+         let shouldUpdateGlucose = currentContext.contains(.glucose)
+@@ -158,11 +158,19 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
+                 let allInsulinCounteractionEffects = state.insulinCounteractionEffects
+                 insulinCounteractionEffects = allInsulinCounteractionEffects.filterDateRange(chartStartDate, nil)
+ 
++                let earliestCounteractionEffect = allInsulinCounteractionEffects.first?.startDate ?? Date()
++                // Show carb entries back through midnight a week ago, or only as far back as counteraction effects are available
++                let boundOnCarbList = max(earliestMidnight, earliestCounteractionEffect)
++                // If counteraction effects are missing, at least show all the entries for today and those on the chart
++                let displayListStart = min(boundOnCarbList, midnight, chartStartDate)
++                // To estimate dynamic carb absorption for the entry at the start of the list, we need to fetch samples that might still be absorbing
++                let fetchEntriesStart = displayListStart.addingTimeInterval(-self.deviceManager.carbStore.maximumAbsorptionTimeInterval)
++
+                 reloadGroup.enter()
+-                self.deviceManager.carbStore.getCarbStatus(start: listStart, end: nil, effectVelocities: allInsulinCounteractionEffects) { (result) in
++                self.deviceManager.carbStore.getCarbStatus(start: fetchEntriesStart, end: nil, effectVelocities: allInsulinCounteractionEffects) { (result) in
+                     switch result {
+                     case .success(let status):
+-                        carbStatuses = status
++                        carbStatuses = status.filterDateRange(displayListStart, nil)
+                         carbsOnBoard = status.getClampedCarbsOnBoard()
+                     case .failure(let error):
+                         self.log.error("CarbStore failed to get carbStatus: %{public}@", String(describing: error))
+@@ -173,7 +181,7 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
+                 }
+ 
+                 reloadGroup.enter()
+-                self.deviceManager.carbStore.getGlucoseEffects(start: chartStartDate, end: nil, effectVelocities: insulinCounteractionEffects!) { (result) in
++                self.deviceManager.carbStore.getGlucoseEffects(start: chartStartDate, end: nil, effectVelocities: allInsulinCounteractionEffects) { (result) in
+                     switch result {
+                     case .success((_, let effects)):
+                         carbEffects = effects
+@@ -287,6 +295,14 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
+         return formatter
+     }()
+ 
++    private lazy var relativeTimeFormatter: DateFormatter = {
++        let formatter = DateFormatter()
++        formatter.dateStyle = .medium
++        formatter.doesRelativeDateFormatting = true
++        formatter.timeStyle = .short
++        return formatter
++    }()
++
+     override func numberOfSections(in tableView: UITableView) -> Int {
+         return Section.count
+     }
+@@ -343,7 +359,14 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
+             }
+ 
+             // Entry time
+-            let startTime = timeFormatter.string(from: status.entry.startDate)
++            let startTime: String
++            // Indicate if an entry is from the previous day to avoid potential confusion
++            let midnight = Calendar.current.startOfDay(for: Date())
++            if status.entry.startDate < midnight {
++                startTime = relativeTimeFormatter.string(from: status.entry.startDate)
++            } else {
++                startTime = timeFormatter.string(from: status.entry.startDate)
++            }
+             if  let absorptionTime = status.entry.absorptionTime,
+                 let duration = absorptionFormatter.string(from: absorptionTime)
+             {


### PR DESCRIPTION
The 7-day patch, meal_week, is slow to plot following an app restart.
Offer a shorter display - meals since midnight of the previous day are included.

See the associated lnl-script [PR 63](https://github.com/loopandlearn/lnl-scripts/pull/63) for testing instructions.