### PR TITLE
G7SensorKit: combine PR 33 (205054e) and PR 34 (25518c5)

### DIFF
--- a/g7_scan/archive/vv_g7_scan.patch
+++ b/g7_scan/archive/vv_g7_scan.patch
@@ -1,4 +1,4 @@
-Submodule G7SensorKit 2be3eb2..9fdb052:
+Submodule G7SensorKit 2be3eb2..59bad50:
 diff --git a/G7SensorKit/G7SensorKit/AlgorithmError.swift b/G7SensorKit/G7SensorKit/AlgorithmError.swift
 index e46f2be..9d83482 100644
 --- a/G7SensorKit/G7SensorKit/AlgorithmError.swift
@@ -96,165 +96,11 @@ index 93e5c40..1bce93f 100644
          }
      }
  }
-diff --git a/G7SensorKit/G7SensorKit/G7CGMManager/G7BluetoothManager.swift b/G7SensorKit/G7SensorKit/G7CGMManager/G7BluetoothManager.swift
-index 62ab5fc..5d9561e 100644
---- a/G7SensorKit/G7SensorKit/G7CGMManager/G7BluetoothManager.swift
-+++ b/G7SensorKit/G7SensorKit/G7CGMManager/G7BluetoothManager.swift
-@@ -101,6 +101,9 @@ class G7BluetoothManager: NSObject {
-             return activePeripheralManager?.peripheral
-         }
-     }
-+    
-+    /// Isolated to `managerQueue`
-+    private var eventRegistrationActive : Bool = false
- 
-     /// Isolated to `managerQueue`
-     private var managedPeripherals: [UUID:G7PeripheralManager] = [:]
-@@ -131,7 +134,7 @@ class G7BluetoothManager: NSObject {
-             self.centralManager = CBCentralManager(delegate: self, queue: managerQueue, options: [CBCentralManagerOptionRestoreIdentifierKey: "com.loudnate.CGMBLEKit"])
-         }
-     }
--
-+    
-     // MARK: - Actions
- 
-     func scanForPeripheral() {
-@@ -177,8 +180,24 @@ class G7BluetoothManager: NSObject {
-             }
-         }
-     }
--
--    private func managerQueue_scanForPeripheral() {
-+    
-+    func centralManager(_ central: CBCentralManager, connectionEventDidOccur event: CBConnectionEvent, for peripheral: CBPeripheral) {
-+    
-+        managerQueue.async {
-+            guard self.eventRegistrationActive else {
-+                self.centralManager.registerForConnectionEvents(options: nil)
-+                return
-+            }
-+            
-+            self.managerQueue_establishActivePeripheral()
-+            
-+            if !self.eventRegistrationActive {
-+                self.centralManager.registerForConnectionEvents(options: nil)
-+            }
-+        }
-+    }
-+                
-+    private func managerQueue_establishActivePeripheral() {
-         dispatchPrecondition(condition: .onQueue(managerQueue))
- 
-         guard centralManager.state == .poweredOn else {
-@@ -187,29 +206,49 @@ class G7BluetoothManager: NSObject {
- 
-         let currentState = activePeripheral?.state ?? .disconnected
-         guard currentState != .connected else {
-+            eventRegistrationActive = false
-             return
-         }
- 
-         if let peripheralID = activePeripheralIdentifier, let peripheral = centralManager.retrievePeripherals(withIdentifiers: [peripheralID]).first {
--            log.debug("Retrieved peripheral %{public}@", peripheral.identifier.uuidString)
-+            log.default("Retrieved peripheral %{public}@", peripheral.identifier.uuidString)
-             handleDiscoveredPeripheral(peripheral)
-         } else {
-             for peripheral in centralManager.retrieveConnectedPeripherals(withServices: [
-                 SensorServiceUUID.advertisement.cbUUID,
-                 SensorServiceUUID.cgmService.cbUUID
-             ]) {
-+                log.default("Found system-connected peripheral: %{public}@", peripheral.identifier.uuidString)
-                 handleDiscoveredPeripheral(peripheral)
-             }
-         }
-+        
-+        if activePeripheral != nil {
-+            eventRegistrationActive = false
-+        }
-+    }
-+
-+    private func managerQueue_scanForPeripheral() {
-+        dispatchPrecondition(condition: .onQueue(managerQueue))
-+        
-+        managerQueue_establishActivePeripheral()
- 
-         if activePeripheral == nil {
--            log.debug("Scanning for peripherals")
-+            log.default("Scanning for peripherals")
-             centralManager.scanForPeripherals(withServices: [
-                     SensorServiceUUID.advertisement.cbUUID
-                 ],
-                 options: nil
-             )
-             delegate?.bluetoothManagerScanningStatusDidChange(self)
-+            
-+            if !eventRegistrationActive {
-+                eventRegistrationActive = true
-+                centralManager.registerForConnectionEvents(options: [CBConnectionEventMatchingOption.serviceUUIDs: [
-+                    SensorServiceUUID.advertisement.cbUUID,
-+                    SensorServiceUUID.cgmService.cbUUID
-+                ]])
-+            }
-         }
-     }
- 
-@@ -221,9 +260,9 @@ class G7BluetoothManager: NSObject {
-      The sleep gives the transmitter time to shut down, but keeps the app running.
- 
-      */
--    fileprivate func scanAfterDelay() {
-+    func scanAfterDelay() {
-         DispatchQueue.global(qos: .utility).async {
--            Thread.sleep(forTimeInterval: 2)
-+            Thread.sleep(forTimeInterval: 5)
- 
-             self.scanForPeripheral()
-         }
-@@ -257,7 +296,7 @@ class G7BluetoothManager: NSObject {
-         if let delegate = delegate {
-             switch delegate.bluetoothManager(self, shouldConnectPeripheral: peripheral) {
-             case .makeActive:
--                log.debug("Making peripheral active: %{public}@", peripheral.identifier.uuidString)
-+                log.default("Making peripheral active: %{public}@", peripheral.identifier.uuidString)
- 
-                 if let peripheralManager = activePeripheralManager {
-                     peripheralManager.peripheral = peripheral
-@@ -273,7 +312,7 @@ class G7BluetoothManager: NSObject {
-                 self.centralManager.connect(peripheral)
- 
-             case .connect:
--                log.debug("Connecting to peripheral: %{public}@", peripheral.identifier.uuidString)
-+                log.default("Connecting to peripheral: %{public}@", peripheral.identifier.uuidString)
-                 self.centralManager.connect(peripheral)
-                 let peripheralManager = G7PeripheralManager(
-                     peripheral: peripheral,
 diff --git a/G7SensorKit/G7SensorKit/G7CGMManager/G7CGMManager.swift b/G7SensorKit/G7SensorKit/G7CGMManager/G7CGMManager.swift
-index 198d5b3..6b2322d 100644
+index 198d5b3..e1793d4 100644
 --- a/G7SensorKit/G7SensorKit/G7CGMManager/G7CGMManager.swift
 +++ b/G7SensorKit/G7SensorKit/G7CGMManager/G7CGMManager.swift
-@@ -237,14 +237,14 @@ public class G7CGMManager: CGMManager {
-         return nil
-     }
- 
--    public func scanForNewSensor() {
-+    public func scanForNewSensor(scanAfterDelay: Bool = false) {
-         logDeviceCommunication("Forgetting existing sensor and starting scan for new sensor.", type: .connection)
- 
-         mutateState { state in
-             state.sensorID = nil
-             state.activatedAt = nil
-         }
--        sensor.scanForNewSensor()
-+        sensor.scanForNewSensor(scanAfterDelay: scanAfterDelay)
-     }
- 
-     private var device: HKDevice? {
-@@ -319,10 +319,15 @@ extension G7CGMManager: G7SensorDelegate {
-     public func sensorDisconnected(_ sensor: G7Sensor, suspectedEndOfSession: Bool) {
-         logDeviceCommunication("Sensor disconnected: suspectedEndOfSession=\(suspectedEndOfSession)", type: .connection)
-         if suspectedEndOfSession {
--            scanForNewSensor()
-+            scanForNewSensor(scanAfterDelay: true)
+@@ -323,6 +323,11 @@ extension G7CGMManager: G7SensorDelegate {
          }
      }
  
@@ -266,7 +112,7 @@ index 198d5b3..6b2322d 100644
      public func sensor(_ sensor: G7Sensor, didError error: Error) {
          logDeviceCommunication("Sensor error \(error)", type: .error)
      }
-@@ -335,6 +340,17 @@ extension G7CGMManager: G7SensorDelegate {
+@@ -335,6 +340,16 @@ extension G7CGMManager: G7SensorDelegate {
              return
          }
  
@@ -280,12 +126,11 @@ index 198d5b3..6b2322d 100644
 +            scanForNewSensor()
 +        }
 +
-+
          guard let activationDate = sensor.activationDate else {
              logDeviceCommunication("Unable to process sensor reading without activation date.", type: .error)
              return
 diff --git a/G7SensorKit/G7SensorKit/G7CGMManager/G7Sensor.swift b/G7SensorKit/G7SensorKit/G7CGMManager/G7Sensor.swift
-index b1745a1..4d38c23 100644
+index b1745a1..a224ee4 100644
 --- a/G7SensorKit/G7SensorKit/G7CGMManager/G7Sensor.swift
 +++ b/G7SensorKit/G7SensorKit/G7CGMManager/G7Sensor.swift
 @@ -19,6 +19,8 @@ public protocol G7SensorDelegate: AnyObject {
@@ -297,25 +142,7 @@ index b1745a1..4d38c23 100644
      func sensor(_ sensor: G7Sensor, didRead glucose: G7GlucoseMessage)
  
      func sensor(_ sensor: G7Sensor, didReadBackfill backfill: [G7BackfillMessage])
-@@ -99,11 +101,15 @@ public final class G7Sensor: G7BluetoothManagerDelegate {
-         bluetoothManager.delegate = self
-     }
- 
--    public func scanForNewSensor() {
-+    public func scanForNewSensor(scanAfterDelay: Bool = false) {
-         self.sensorID = nil
-         bluetoothManager.disconnect()
-         bluetoothManager.forgetPeripheral()
--        bluetoothManager.scanForPeripheral()
-+        if scanAfterDelay {
-+            bluetoothManager.scanAfterDelay()
-+        } else {
-+            bluetoothManager.scanForPeripheral()
-+        }
-     }
- 
-     public func resumeScanning() {
-@@ -194,7 +200,10 @@ public final class G7Sensor: G7BluetoothManagerDelegate {
+@@ -194,7 +196,10 @@ public final class G7Sensor: G7BluetoothManagerDelegate {
          if let sensorID = sensorID, sensorID == peripheralManager.peripheral.name {
  
              let suspectedEndOfSession: Bool
@@ -327,7 +154,7 @@ index b1745a1..4d38c23 100644
                  suspectedEndOfSession = true // Normal disconnect without auth is likely that G7 app stopped this session
              } else {
                  suspectedEndOfSession = false
-@@ -233,7 +242,7 @@ public final class G7Sensor: G7BluetoothManagerDelegate {
+@@ -233,7 +238,7 @@ public final class G7Sensor: G7BluetoothManagerDelegate {
  
          guard response.count > 0 else { return }
  
@@ -336,7 +163,7 @@ index b1745a1..4d38c23 100644
  
          switch G7Opcode(rawValue: response[0]) {
          case .glucoseTx?:
-@@ -252,7 +261,7 @@ public final class G7Sensor: G7BluetoothManagerDelegate {
+@@ -252,7 +257,7 @@ public final class G7Sensor: G7BluetoothManagerDelegate {
                  }
              }
          default:


### PR DESCRIPTION
One Looper consistently lost G7 signal following a quit/restart of Loop. It would take 3 to 12 hours before the G7 signal was picked up again.

This Looper was running the customization which included G7SignalKit PR 34 SHA 25518c5.

After merging in the changes from G7SignalKit PR 33 SHA 205054e to the changes from PR 34, she was able to quit and restart without loss of signal.

This PR provides the combination of PR 33 and PR 34 for Loop users.

To test this:

First add this command to the Terminal
```
export PATCH_BRANCH=g7_pr34_pr33_update
```

Then run normal customization script
```
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/loopandlearn/lnl-scripts/main/CustomizationSelect.sh)"
```