### PR TITLE
Updates to be compatible with dev v3.7.7

### DIFF
--- a/basal_lock/dev377_basal_lock.patch
+++ b/basal_lock/dev377_basal_lock.patch
@@ -1,0 +1,1193 @@
+Submodule Loop contains modified content
+diff --git a/Loop/Loop.xcodeproj/project.pbxproj b/Loop/Loop.xcodeproj/project.pbxproj
+index 11819516..a22646b3 100644
+--- a/Loop/Loop.xcodeproj/project.pbxproj
++++ b/Loop/Loop.xcodeproj/project.pbxproj
+@@ -489,6 +489,7 @@
+ 		C1FB428F217921D600FAB378 /* PumpManagerUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FB428E217921D600FAB378 /* PumpManagerUI.swift */; };
+ 		C1FB4290217922A100FAB378 /* PumpManagerUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FB428E217921D600FAB378 /* PumpManagerUI.swift */; };
+ 		DD3DBD292A33AFE9000F8B5B /* IntegralRetrospectiveCorrectionSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3DBD282A33AFE9000F8B5B /* IntegralRetrospectiveCorrectionSelectionView.swift */; };
++		DDC065142B65871E0033FD88 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC065132B65871E0033FD88 /* Preferences.swift */; };
+ 		DDC389F62A2B61750066E2E8 /* ApplicationFactorStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC389F52A2B61750066E2E8 /* ApplicationFactorStrategy.swift */; };
+ 		DDC389F82A2B620B0066E2E8 /* GlucoseBasedApplicationFactorStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC389F72A2B620B0066E2E8 /* GlucoseBasedApplicationFactorStrategy.swift */; };
+ 		DDC389FA2A2B62470066E2E8 /* ConstantApplicationFactorStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC389F92A2B62470066E2E8 /* ConstantApplicationFactorStrategy.swift */; };
+@@ -1292,6 +1293,7 @@
+ 		C1FB428B217806A300FAB378 /* StateColorPalette.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateColorPalette.swift; sourceTree = "<group>"; };
+ 		C1FB428E217921D600FAB378 /* PumpManagerUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PumpManagerUI.swift; sourceTree = "<group>"; };
+ 		DD3DBD282A33AFE9000F8B5B /* IntegralRetrospectiveCorrectionSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegralRetrospectiveCorrectionSelectionView.swift; sourceTree = "<group>"; };
++		DDC065132B65871E0033FD88 /* Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
+ 		DDC389F52A2B61750066E2E8 /* ApplicationFactorStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationFactorStrategy.swift; sourceTree = "<group>"; };
+ 		DDC389F72A2B620B0066E2E8 /* GlucoseBasedApplicationFactorStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseBasedApplicationFactorStrategy.swift; sourceTree = "<group>"; };
+ 		DDC389F92A2B62470066E2E8 /* ConstantApplicationFactorStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantApplicationFactorStrategy.swift; sourceTree = "<group>"; };
+@@ -1960,6 +1962,7 @@
+ 				C1E3862428247B7100F561A4 /* StoredLoopNotRunningNotification.swift */,
+ 				4328E0311CFC068900E199AA /* WatchContext+LoopKit.swift */,
+ 				A987CD4824A58A0100439ADC /* ZipArchive.swift */,
++				DDC065132B65871E0033FD88 /* Preferences.swift */,
+ 			);
+ 			path = Models;
+ 			sourceTree = "<group>";
+@@ -3742,6 +3745,7 @@
+ 				E98A55EF24EDD6E60008715D /* DosingDecisionStoreProtocol.swift in Sources */,
+ 				B4001CEE28CBBC82002FB414 /* AlertManagementView.swift in Sources */,
+ 				E9C00EF524C623EF00628F35 /* LoopSettings+Loop.swift in Sources */,
++				DDC065142B65871E0033FD88 /* Preferences.swift in Sources */,
+ 				4389916B1E91B689000EEF90 /* ChartSettings+Loop.swift in Sources */,
+ 				C178249A1E1999FA00D9D25C /* CaseCountable.swift in Sources */,
+ 				B4F3D25124AF890C0095CE44 /* BluetoothStateManager.swift in Sources */,
+diff --git a/Loop/Loop/Managers/LoopDataManager.swift b/Loop/Loop/Managers/LoopDataManager.swift
+index 2319f4ec..c3f0c422 100644
+--- a/Loop/Loop/Managers/LoopDataManager.swift
++++ b/Loop/Loop/Managers/LoopDataManager.swift
+@@ -1549,7 +1549,8 @@ extension LoopDataManager {
+             model: model,
+             pendingInsulin: 0, // Pending insulin is already reflected in the prediction
+             maxBolus: maxBolus,
+-            volumeRounder: volumeRounder
++            volumeRounder: volumeRounder,
++            preferences: Preferences.shared
+         )
+     }
+ 
+@@ -1832,7 +1833,8 @@ extension LoopDataManager {
+                     lastTempBasal: lastTempBasal,
+                     volumeRounder: volumeRounder,
+                     rateRounder: rateRounder,
+-                    isBasalRateScheduleOverrideActive: settings.scheduleOverride?.isBasalRateScheduleOverriden(at: startDate) == true
++                    isBasalRateScheduleOverrideActive: settings.scheduleOverride?.isBasalRateScheduleOverriden(at: startDate) == true,
++                    preferences: Preferences.shared
+                 )
+             case .tempBasalOnly:
+ 
+@@ -1847,7 +1849,8 @@ extension LoopDataManager {
+                     additionalActiveInsulinClamp: iobHeadroom,
+                     lastTempBasal: lastTempBasal,
+                     rateRounder: rateRounder,
+-                    isBasalRateScheduleOverrideActive: settings.scheduleOverride?.isBasalRateScheduleOverriden(at: startDate) == true
++                    isBasalRateScheduleOverrideActive: settings.scheduleOverride?.isBasalRateScheduleOverriden(at: startDate) == true,
++                    preferences: Preferences.shared
+                 )
+                 dosingRecommendation = AutomaticDoseRecommendation(basalAdjustment: temp)
+             }
+diff --git a/Loop/Loop/Models/Preferences.swift b/Loop/Loop/Models/Preferences.swift
+new file mode 100644
+index 00000000..dc9150f8
+--- /dev/null
++++ b/Loop/Loop/Models/Preferences.swift
+@@ -0,0 +1,50 @@
++//
++//  Preferences.swift
++//  Loop
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import LoopKit
++import HealthKit
++
++struct Preferences: PreferencesProvider {
++    
++    static var shared = Preferences()
++    
++    private init() {}
++    
++    // Basal Lock Threshold
++    var basalLockThreshold: HKQuantity {
++        get {
++            let key = "basalLockThreshold"
++            if let value = UserDefaults.standard.value(forKey: key) as? Double {
++                return HKQuantity(unit: .milligramsPerDeciliter, doubleValue: value)
++            } else {
++                return HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 250)
++            }
++        }
++        set {
++            let key = "basalLockThreshold"
++            let value = newValue.doubleValue(for: .milligramsPerDeciliter)
++            UserDefaults.standard.set(value, forKey: key)
++        }
++    }
++    
++    // Basal Lock Enabled
++    var isBasalLockEnabled: Bool {
++        get {
++            let key = "isBasalLockEnabled"
++            if UserDefaults.standard.object(forKey: key) == nil {
++                return false
++            }
++            return UserDefaults.standard.bool(forKey: key)
++        }
++        set {
++            let key = "isBasalLockEnabled"
++            UserDefaults.standard.set(newValue, forKey: key)
++        }
++    }
++}
+diff --git a/Loop/Loop/Views/SettingsView.swift b/Loop/Loop/Views/SettingsView.swift
+index c3ec98b8..60e36b9a 100644
+--- a/Loop/Loop/Views/SettingsView.swift
++++ b/Loop/Loop/Views/SettingsView.swift
+@@ -51,6 +51,7 @@ public struct SettingsView: View {
+             
+             case favoriteFoods
+             case therapySettings
++            case preferences
+         }
+     }
+     
+@@ -85,6 +86,9 @@ public struct SettingsView: View {
+                     if FeatureFlags.allowExperimentalFeatures {
+                         favoriteFoodsSection
+                     }
++                    if FeatureFlags.allowExperimentalFeatures {
++                        preferencesSection
++                    }
+                     if (viewModel.pumpManagerSettingsViewModel.isTestingDevice || viewModel.cgmManagerSettingsViewModel.isTestingDevice) && viewModel.showDeleteTestData {
+                         deleteDataSection
+                     }
+@@ -157,6 +161,8 @@ public struct SettingsView: View {
+                     .environment(\.insulinTintColor, self.insulinTintColor)
+                 case .favoriteFoods:
+                     FavoriteFoodsView()
++                case .preferences:
++                    PreferencesView(viewModel: PreferencesViewModel(preferencesProvider: Preferences.shared)).environmentObject(displayGlucosePreference)
+                 }
+             }
+         }
+@@ -374,6 +380,16 @@ extension SettingsView {
+         }
+     }
+     
++    private var preferencesSection: some View {
++        Section {
++            LargeButton(action: { sheet = .preferences },
++                        includeArrow: true,
++                        imageView: AnyView(Image(systemName: "gearshape.fill").font(.system(size: 30, weight: .bold))),
++                        label: NSLocalizedString("Preferences", comment: "Title text for button to Preferences"),
++                        descriptiveText: NSLocalizedString("Customize your Loop experience by adjusting additional settings", comment: "Descriptive text for Preferences"))
++        }
++    }
++
+     private var cgmChoices: [ActionSheet.Button] {
+         var result = viewModel.cgmManagerSettingsViewModel.availableDevices
+             .sorted(by: {$0.localizedTitle < $1.localizedTitle})
+Submodule LoopKit contains modified content
+diff --git a/LoopKit/LoopKit.xcodeproj/project.pbxproj b/LoopKit/LoopKit.xcodeproj/project.pbxproj
+index 2ecb6c53..6e177b30 100644
+--- a/LoopKit/LoopKit.xcodeproj/project.pbxproj
++++ b/LoopKit/LoopKit.xcodeproj/project.pbxproj
+@@ -863,6 +863,13 @@
+ 		C1FAEC1D264AD6B400A3250B /* DeviceStatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FAEC1C264AD6B400A3250B /* DeviceStatusBadge.swift */; };
+ 		C1FAEC1F264AE12700A3250B /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47ECF8725DC20810024A54D /* UIImage.swift */; };
+ 		C1FAEC21264AEEA300A3250B /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FAEC20264AEEA300A3250B /* UIImage.swift */; };
++		DD13BC702C3C71A70062313B /* BasalLockEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD13BC6F2C3C71A70062313B /* BasalLockEditor.swift */; };
++		DD13BC722C3C74CD0062313B /* PreferencesGuardrailWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD13BC712C3C74CD0062313B /* PreferencesGuardrailWarning.swift */; };
++		DD28B3712B80C074001044D4 /* PreferencesSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD28B3702B80C074001044D4 /* PreferencesSetting.swift */; };
++		DD545A5B2B80ECB900915F95 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD545A5A2B80ECB900915F95 /* PreferencesView.swift */; };
++		DD545A5F2B80EFA900915F95 /* PreferencesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD545A5E2B80EFA900915F95 /* PreferencesViewModel.swift */; };
++		DD545A652B814CA800915F95 /* PreferencesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD545A642B814CA800915F95 /* PreferencesProvider.swift */; };
++		DD545A692B8BCF8E00915F95 /* Guardrail+Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD545A682B8BCF8E00915F95 /* Guardrail+Preferences.swift */; };
+ 		E9077D2724ACD59F0066A88D /* InformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9077D2624ACD59F0066A88D /* InformationView.swift */; };
+ 		E9077D2A24ACDE2C0066A88D /* CorrectionRangeInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9077D2924ACDE2C0066A88D /* CorrectionRangeInformationView.swift */; };
+ 		E9086B2924B39EDC0062F5C8 /* ChartsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B2824B39EDC0062F5C8 /* ChartsTableViewController.swift */; };
+@@ -1790,6 +1797,13 @@
+ 		C1FAC06228C7B0A100754AE2 /* reservoir_iob_test.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reservoir_iob_test.json; sourceTree = "<group>"; };
+ 		C1FAEC1C264AD6B400A3250B /* DeviceStatusBadge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceStatusBadge.swift; sourceTree = "<group>"; };
+ 		C1FAEC20264AEEA300A3250B /* UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
++		DD13BC6F2C3C71A70062313B /* BasalLockEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasalLockEditor.swift; sourceTree = "<group>"; };
++		DD13BC712C3C74CD0062313B /* PreferencesGuardrailWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesGuardrailWarning.swift; sourceTree = "<group>"; };
++		DD28B3702B80C074001044D4 /* PreferencesSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesSetting.swift; sourceTree = "<group>"; };
++		DD545A5A2B80ECB900915F95 /* PreferencesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
++		DD545A5E2B80EFA900915F95 /* PreferencesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesViewModel.swift; sourceTree = "<group>"; };
++		DD545A642B814CA800915F95 /* PreferencesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesProvider.swift; sourceTree = "<group>"; };
++		DD545A682B8BCF8E00915F95 /* Guardrail+Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Guardrail+Preferences.swift"; sourceTree = "<group>"; };
+ 		E9077D2624ACD59F0066A88D /* InformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationView.swift; sourceTree = "<group>"; };
+ 		E9077D2924ACDE2C0066A88D /* CorrectionRangeInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeInformationView.swift; sourceTree = "<group>"; };
+ 		E9086B2824B39EDC0062F5C8 /* ChartsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartsTableViewController.swift; sourceTree = "<group>"; };
+@@ -2271,6 +2285,7 @@
+ 		4369F090208B0D68000E3E45 /* Views */ = {
+ 			isa = PBXGroup;
+ 			children = (
++				DD545A592B80EC9500915F95 /* Preferences Editors */,
+ 				B4C004B2241085DB00B40429 /* ActionButton.swift */,
+ 				89AF78C524482268002B4FCC /* ActionButtonStyle.swift */,
+ 				C1E4B307242E995200E70CCB /* ActivityIndicator.swift */,
+@@ -2441,6 +2456,7 @@
+ 				C187338229B9486200519CDF /* TimeInterval.swift */,
+ 				C187339629B9488300519CDF /* TimeZone.swift */,
+ 				C187339729B9488300519CDF /* UUID.swift */,
++				DD545A682B8BCF8E00915F95 /* Guardrail+Preferences.swift */,
+ 			);
+ 			path = Extensions;
+ 			sourceTree = "<group>";
+@@ -2649,6 +2665,8 @@
+ 				C1814B8B226371DF008D2D8E /* WeakSynchronizedDelegate.swift */,
+ 				43CACE0D2247F89100F90AF5 /* WeakSynchronizedSet.swift */,
+ 				B4A2ABEE2AAB5160007E3EC1 /* Pluggable.swift */,
++				DD28B3702B80C074001044D4 /* PreferencesSetting.swift */,
++				DD545A642B814CA800915F95 /* PreferencesProvider.swift */,
+ 			);
+ 			path = LoopKit;
+ 			sourceTree = "<group>";
+@@ -3169,6 +3187,7 @@
+ 				B455F48025FF9A8B000ED456 /* InsulinSensitivityScheduleEditorViewModel.swift */,
+ 				B455F2A125FBE985000ED456 /* SuspendThresholdEditorViewModel.swift */,
+ 				1D1FCE2424BD42EF000300A8 /* TherapySettingsViewModel.swift */,
++				DD545A5E2B80EFA900915F95 /* PreferencesViewModel.swift */,
+ 			);
+ 			path = ViewModels;
+ 			sourceTree = "<group>";
+@@ -3294,6 +3313,16 @@
+ 			path = LoopAlgorithm;
+ 			sourceTree = "<group>";
+ 		};
++		DD545A592B80EC9500915F95 /* Preferences Editors */ = {
++			isa = PBXGroup;
++			children = (
++				DD545A5A2B80ECB900915F95 /* PreferencesView.swift */,
++				DD13BC6F2C3C71A70062313B /* BasalLockEditor.swift */,
++				DD13BC712C3C74CD0062313B /* PreferencesGuardrailWarning.swift */,
++			);
++			path = "Preferences Editors";
++			sourceTree = "<group>";
++		};
+ 		E9077D2824ACD5AA0066A88D /* Information Screens */ = {
+ 			isa = PBXGroup;
+ 			children = (
+@@ -4052,6 +4081,7 @@
+ 				B4A2AAB1240830A30066563F /* LabeledTextField.swift in Sources */,
+ 				A9D3FF0B2A6C198C000C891D /* CGPoint.swift in Sources */,
+ 				B429D66E24BF7255003E1B4A /* UIImage.swift in Sources */,
++				DD13BC722C3C74CD0062313B /* PreferencesGuardrailWarning.swift in Sources */,
+ 				B46B62A923FF05F8001E69BA /* LabeledNumberInput.swift in Sources */,
+ 				892155152245C57E009112BC /* SegmentedGaugeBarLayer.swift in Sources */,
+ 				C1DD512B259FD8A600DE27AE /* InsulinTypeChooser.swift in Sources */,
+@@ -4087,6 +4117,7 @@
+ 				A9D3FF042A6C1944000C891D /* PredictedGlucoseChart.swift in Sources */,
+ 				C1DE4C2125A253BD007065F8 /* Color.swift in Sources */,
+ 				898E6E702241EDB70019E459 /* PercentageTextFieldTableViewController.swift in Sources */,
++				DD13BC702C3C71A70062313B /* BasalLockEditor.swift in Sources */,
+ 				89CAB36D24C9EC98009EE3CE /* Keyboard.swift in Sources */,
+ 				89186C0724BF7FC70003D0F3 /* Guardrail+UI.swift in Sources */,
+ 				43FB60E520DCBA02002B996B /* SetupTableViewController.swift in Sources */,
+@@ -4137,6 +4168,7 @@
+ 				B46B62B323FF0E62001E69BA /* SelectableLabel.swift in Sources */,
+ 				89FC6893245A2D680075CF59 /* ScheduleItemView.swift in Sources */,
+ 				43BA716F201E49220058961E /* FoodEmojiDataSource.swift in Sources */,
++				DD545A5F2B80EFA900915F95 /* PreferencesViewModel.swift in Sources */,
+ 				E9077D2724ACD59F0066A88D /* InformationView.swift in Sources */,
+ 				E94141D024C8F31C0096C326 /* DeliveryLimitsEditor.swift in Sources */,
+ 				1452F4BA2A85266500F8B9E4 /* CarbQuantityRow.swift in Sources */,
+@@ -4200,6 +4232,7 @@
+ 				43BA717D201EE7090058961E /* GlucoseRangeTableViewCell.swift in Sources */,
+ 				B455F3A425FF7FF0000ED456 /* CorrectionRangeOverridesEditorViewModel.swift in Sources */,
+ 				A9D3FF002A6C1944000C891D /* ChartConstants.swift in Sources */,
++				DD545A5B2B80ECB900915F95 /* PreferencesView.swift in Sources */,
+ 				89BE75CB2464BC2000B145D9 /* AlertContent.swift in Sources */,
+ 				43BA7184201EE7090058961E /* TextFieldTableViewController.swift in Sources */,
+ 				1452F4B22A8521CD00F8B9E4 /* TextFieldRow.swift in Sources */,
+@@ -4288,6 +4321,7 @@
+ 				89AE222F228BC68000BDFD85 /* DoseProgressTimerEstimator.swift in Sources */,
+ 				43D8FDF61C7290350073BE78 /* DailyQuantitySchedule.swift in Sources */,
+ 				43D8FDF51C7290350073BE78 /* CarbRatioSchedule.swift in Sources */,
++				DD545A652B814CA800915F95 /* PreferencesProvider.swift in Sources */,
+ 				4322B76F202FA26F0002837D /* GlucoseSampleValue.swift in Sources */,
+ 				89AE222C228BC66E00BDFD85 /* Locked.swift in Sources */,
+ 				432CF87120D76D5A0066B889 /* GlucoseDisplayable.swift in Sources */,
+@@ -4357,6 +4391,7 @@
+ 				A93761C125ED670200F6BE43 /* BluetoothProvider.swift in Sources */,
+ 				433BC7A720523DB7000B1200 /* NewGlucoseSample.swift in Sources */,
+ 				4322B78E202FA2B30002837D /* InsulinMath.swift in Sources */,
++				DD28B3712B80C074001044D4 /* PreferencesSetting.swift in Sources */,
+ 				C17F39D023CE34B100FA1113 /* StoredDeviceLogEntry.swift in Sources */,
+ 				43B17C89208EEC0B00AC27E9 /* HealthStoreUnitCache.swift in Sources */,
+ 				A912BE29245B9CD500CBE199 /* SettingsObject+CoreDataClass.swift in Sources */,
+@@ -4383,6 +4418,7 @@
+ 				A932803B2798D63B0091D0A1 /* SyncAlertObject.swift in Sources */,
+ 				1D841AAD24577EE10069DBFF /* AlertSoundPlayer.swift in Sources */,
+ 				C19E776B2A61FD8A003F06C5 /* RetrospectiveCorrection.swift in Sources */,
++				DD545A692B8BCF8E00915F95 /* Guardrail+Preferences.swift in Sources */,
+ 				C187339A29B9488300519CDF /* UUID.swift in Sources */,
+ 				C1CAB9E926A3254800A57273 /* StoredInsulinModel.swift in Sources */,
+ 				43CACE0E2247F89100F90AF5 /* WeakSynchronizedSet.swift in Sources */,
+diff --git a/LoopKit/LoopKit/Extensions/Guardrail+Preferences.swift b/LoopKit/LoopKit/Extensions/Guardrail+Preferences.swift
+new file mode 100644
+index 00000000..e413f7b5
+--- /dev/null
++++ b/LoopKit/LoopKit/Extensions/Guardrail+Preferences.swift
+@@ -0,0 +1,18 @@
++//
++//  Guardrail+Preferences.swift
++//  LoopKit
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import HealthKit
++
++public extension Guardrail where Value == HKQuantity {
++    static let basalLockThreshold = Guardrail(
++        absoluteBounds: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 200)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 300),
++        recommendedBounds: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 220)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 300),
++        startingSuggestion: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 250)
++    )
++}
+diff --git a/LoopKit/LoopKit/LoopAlgorithm/DoseMath.swift b/LoopKit/LoopKit/LoopAlgorithm/DoseMath.swift
+index f4b8d44a..1151ff12 100644
+--- a/LoopKit/LoopKit/LoopAlgorithm/DoseMath.swift
++++ b/LoopKit/LoopKit/LoopAlgorithm/DoseMath.swift
+@@ -231,7 +231,8 @@ extension Collection where Element: GlucoseValue {
+         at date: Date,
+         suspendThreshold: HKQuantity,
+         sensitivity: HKQuantity,
+-        model: InsulinModel
++        model: InsulinModel,
++        preferences: PreferencesProvider
+     ) -> InsulinCorrection? {
+         let effectDuration = model.effectDuration
+         let timeline = [AbsoluteScheduleValue(startDate: date, endDate: date.addingTimeInterval(effectDuration), value: sensitivity)]
+@@ -240,7 +241,8 @@ extension Collection where Element: GlucoseValue {
+             at: date,
+             suspendThreshold: suspendThreshold,
+             insulinSensitivityTimeline: timeline,
+-            model: model)
++            model: model,
++            preferences: preferences)
+     }
+ 
+     /// For a collection of glucose prediction, determine the least amount of insulin delivered at
+@@ -258,7 +260,8 @@ extension Collection where Element: GlucoseValue {
+         at date: Date,
+         suspendThreshold: HKQuantity,
+         insulinSensitivityTimeline: [AbsoluteScheduleValue<HKQuantity>],
+-        model: InsulinModel
++        model: InsulinModel,
++        preferences: PreferencesProvider
+     ) -> InsulinCorrection? {
+         var minGlucose: GlucoseValue?
+         var eventualGlucose: GlucoseValue?
+@@ -402,14 +405,16 @@ extension Collection where Element: GlucoseValue {
+         rateRounder: ((Double) -> Double)? = nil,
+         isBasalRateScheduleOverrideActive: Bool = false,
+         duration: TimeInterval = TimeInterval(30 * 60),
+-        continuationInterval: TimeInterval = TimeInterval(60 * 11)
++        continuationInterval: TimeInterval = TimeInterval(60 * 11),
++        preferences: PreferencesProvider
+     ) -> TempBasalRecommendation? {
+         let correction = self.insulinCorrection(
+             to: correctionRange,
+             at: date,
+             suspendThreshold: suspendThreshold ?? correctionRange.quantityRange(at: date).lowerBound,
+             sensitivity: sensitivity.quantity(at: date),
+-            model: model
++            model: model,
++            preferences: preferences
+         )
+ 
+         let scheduledBasalRate = basalRates.value(at: date)
+@@ -427,13 +432,22 @@ extension Collection where Element: GlucoseValue {
+             maxBasalRate = Swift.min(maxThirtyMinuteRateToKeepIOBBelowLimit, maxBasalRate)
+         }
+ 
+-        let temp = correction?.asTempBasal(
++        var temp = correction?.asTempBasal(
+             scheduledBasalRate: scheduledBasalRate,
+             maxBasalRate: maxBasalRate,
+             duration: duration,
+             rateRounder: rateRounder
+         )
+ 
++        if (preferences.isBasalLockEnabled && ( temp?.unitsPerHour ?? scheduledBasalRate < scheduledBasalRate  ||
++             lastTempBasal?.unitsPerHour ?? scheduledBasalRate < scheduledBasalRate
++             ) &&
++            self[0 as! Self.Index].quantity > preferences.basalLockThreshold)
++        {
++            print("####### Temp Basal Lock On #########")
++            temp = TempBasalRecommendation(unitsPerHour: scheduledBasalRate, duration: 1800)
++        }
++
+         return temp?.ifNecessary(
+             at: date,
+             scheduledBasalRate: scheduledBasalRate,
+@@ -475,14 +489,16 @@ extension Collection where Element: GlucoseValue {
+         rateRounder: ((Double) -> Double)? = nil,
+         isBasalRateScheduleOverrideActive: Bool = false,
+         duration: TimeInterval = TimeInterval(30 * 60),
+-        continuationInterval: TimeInterval = TimeInterval(11 * 60)
++        continuationInterval: TimeInterval = TimeInterval(11 * 60),
++        preferences: PreferencesProvider
+     ) -> AutomaticDoseRecommendation? {
+         guard let correction = self.insulinCorrection(
+             to: correctionRange,
+             at: date,
+             suspendThreshold: suspendThreshold ?? correctionRange.quantityRange(at: date).lowerBound,
+             sensitivity: sensitivity.quantity(at: date),
+-            model: model
++            model: model,
++            preferences: preferences
+         ) else {
+             return nil
+         }
+@@ -517,6 +533,15 @@ extension Collection where Element: GlucoseValue {
+             volumeRounder: volumeRounder
+         )
+ 
++        if (preferences.isBasalLockEnabled && (temp?.unitsPerHour ?? scheduledBasalRate < scheduledBasalRate ||
++              lastTempBasal?.unitsPerHour ?? scheduledBasalRate < scheduledBasalRate
++              ) &&
++            self[0 as! Self.Index].quantity > preferences.basalLockThreshold)
++        {
++            print("####### Temp Basal Lock On #########")
++            temp = TempBasalRecommendation(unitsPerHour: scheduledBasalRate, duration: 1800)
++        }
++
+         if temp != nil || bolusUnits > 0 {
+             return AutomaticDoseRecommendation(basalAdjustment: temp, bolusUnits: bolusUnits)
+         }
+@@ -545,14 +570,16 @@ extension Collection where Element: GlucoseValue {
+         model: InsulinModel,
+         pendingInsulin: Double,
+         maxBolus: Double,
+-        volumeRounder: ((Double) -> Double)? = nil
++        volumeRounder: ((Double) -> Double)? = nil,
++        preferences: PreferencesProvider
+     ) -> ManualBolusRecommendation {
+         guard let correction = self.insulinCorrection(
+             to: correctionRange,
+             at: date,
+             suspendThreshold: suspendThreshold ?? correctionRange.quantityRange(at: date).lowerBound,
+             sensitivity: sensitivity.quantity(at: date),
+-            model: model
++            model: model,
++            preferences: preferences
+         ) else {
+             return ManualBolusRecommendation(amount: 0, pendingInsulin: pendingInsulin)
+         }
+diff --git a/LoopKit/LoopKit/PreferencesProvider.swift b/LoopKit/LoopKit/PreferencesProvider.swift
+new file mode 100644
+index 00000000..a164defb
+--- /dev/null
++++ b/LoopKit/LoopKit/PreferencesProvider.swift
+@@ -0,0 +1,15 @@
++//
++//  PreferencesProvider.swift
++//  LoopKit
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import HealthKit
++
++public protocol PreferencesProvider {
++    var basalLockThreshold: HKQuantity { get set }
++    var isBasalLockEnabled: Bool { get set }
++}
+diff --git a/LoopKit/LoopKit/PreferencesSetting.swift b/LoopKit/LoopKit/PreferencesSetting.swift
+new file mode 100644
+index 00000000..0de6928d
+--- /dev/null
++++ b/LoopKit/LoopKit/PreferencesSetting.swift
+@@ -0,0 +1,60 @@
++//
++//  PreferencesSetting.swift
++//  LoopKit
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++
++public enum PreferencesSetting {
++    case basalLock
++}
++
++extension PreferencesSetting: Equatable { }
++
++public extension PreferencesSetting {
++    var title: String {
++        switch self {
++        case .basalLock:
++            return LocalizedString("Basal Lock", comment: "Title text for basal lock setting")
++        }
++    }
++    
++    var smallTitle: String {
++        return title
++    }
++    
++    func descriptiveText(appName: String) -> String {
++        switch self {
++        case .basalLock:
++            return String(format: LocalizedString("Basal Lock prevents the basal rate from being throttled if the blood glucose is above a certain level.", comment: "Descriptive text for basal lock (1: app name)"), appName)
++        }
++    }
++}
++
++// MARK: Guardrails
++public extension PreferencesSetting {
++    var guardrailCaptionForLowValue: String {
++        switch self {
++        case .basalLock:
++            return LocalizedString("The value you have entered is lower than what is typically recommended.", comment: "Descriptive text for guardrail low value warning for basal lock")
++        }
++    }
++    
++    var guardrailCaptionForHighValue: String {
++        switch self {
++        case .basalLock:
++            return LocalizedString("The value you have entered is higher than what is typically recommended.", comment: "Descriptive text for guardrail high value warning for basal lock")
++        }
++    }
++    
++    var guardrailCaptionForOutsideValues: String {
++        return LocalizedString("The value you have entered for Basal Lock is outside of the recommended range.", comment: "Descriptive text for guardrail outside value warning for basal lock")
++    }
++    
++    var guardrailSaveWarningCaption: String {
++        return LocalizedString("Please note that this value is outside of the recommended range.", comment: "Descriptive text for saving settings outside the recommended range for basal lock")
++    }
++}
+diff --git a/LoopKit/LoopKitUI/ViewModels/PreferencesViewModel.swift b/LoopKit/LoopKitUI/ViewModels/PreferencesViewModel.swift
+new file mode 100644
+index 00000000..785a23f1
+--- /dev/null
++++ b/LoopKit/LoopKitUI/ViewModels/PreferencesViewModel.swift
+@@ -0,0 +1,34 @@
++//
++//  PreferencesViewModel.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import LoopKit
++import HealthKit
++
++public class PreferencesViewModel: ObservableObject {
++    @Published var basalLockThreshold: HKQuantity
++    @Published var isBasalLockEnabled: Bool
++    
++    private var preferencesProvider: PreferencesProvider
++    
++    public init(preferencesProvider: PreferencesProvider) {
++        self.preferencesProvider = preferencesProvider
++        self.basalLockThreshold = preferencesProvider.basalLockThreshold
++        self.isBasalLockEnabled = preferencesProvider.isBasalLockEnabled
++    }
++    
++    func updateBasalLockThreshold(_ newValue: HKQuantity) {
++        preferencesProvider.basalLockThreshold = newValue
++        self.basalLockThreshold = newValue
++    }
++    
++    func updateBasalLockEnabled(_ newValue: Bool) {
++        preferencesProvider.isBasalLockEnabled = newValue
++        self.isBasalLockEnabled = newValue
++    }
++}
+diff --git a/LoopKit/LoopKitUI/Views/GuardrailConstrainedTimeIntervalView.swift b/LoopKit/LoopKitUI/Views/GuardrailConstrainedTimeIntervalView.swift
+new file mode 100644
+index 00000000..c473fd51
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/GuardrailConstrainedTimeIntervalView.swift
+@@ -0,0 +1,122 @@
++//
++//  GuardrailConstrainedTimeIntervalView.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import SwiftUI
++import HealthKit
++import LoopKit
++
++
++public struct GuardrailConstrainedTimeIntervalView: View {
++    @Environment(\.guidanceColors) var guidanceColors
++    var value: TimeInterval?
++    var guardrail: Guardrail<TimeInterval>
++    var isEditing: Bool
++    var isSupportedValue: Bool
++    var formatter: DateComponentsFormatter
++    var iconSpacing: CGFloat
++    var isUnitLabelVisible: Bool
++    var forceDisableAnimations: Bool
++    
++    @State private var hasAppeared = false
++    
++    public init(
++        value: TimeInterval,
++        guardrail: Guardrail<TimeInterval>,
++        isEditing: Bool,
++        isSupportedValue: Bool = true,
++        iconSpacing: CGFloat = 8,
++        isUnitLabelVisible: Bool = true,
++        forceDisableAnimations: Bool = false
++    ) {
++        self.value = value
++        self.guardrail = guardrail
++        self.isEditing = isEditing
++        self.isSupportedValue = isSupportedValue
++        self.iconSpacing = iconSpacing
++        self.isUnitLabelVisible = isUnitLabelVisible
++        self.forceDisableAnimations = forceDisableAnimations
++        
++        
++        self.formatter = {
++            let formatter = DateComponentsFormatter()
++            formatter.allowedUnits = [.hour, .minute]
++            formatter.unitsStyle = .short
++            formatter.zeroFormattingBehavior = [.dropLeading, .dropTrailing]
++            
++            return formatter
++        }()
++    }
++    
++    public var body: some View {
++        HStack {
++            HStack(spacing: iconSpacing) {
++                if value != nil {
++                    if guardrail.classification(for: value!) != .withinRecommendedRange {
++                        Image(systemName: "exclamationmark.triangle.fill")
++                            .foregroundColor(warningColor)
++                            .transition(.springInDisappear)
++                    }
++                    
++                    Text(formatter.string(from: value!) ?? "")
++                        .foregroundColor(warningColor)
++                        .fixedSize(horizontal: true, vertical: false)
++                } else {
++                    Text("–")
++                        .foregroundColor(.secondary)
++                }
++            }
++            
++/*            if isUnitLabelVisible {
++                Text(unit.shortLocalizedUnitString())
++                    .foregroundColor(Color(.secondaryLabel))
++            }*/
++        }
++        .accessibilityElement(children: .combine)
++        .onAppear { self.hasAppeared = true }
++        .animation(animation)
++    }
++    
++    private var animation: Animation? {
++        // A conditional implicit animation seems to behave funky on first appearance.
++        // Disable animations until the view has appeared.
++        if forceDisableAnimations || !hasAppeared {
++            return nil
++        }
++        
++        // While editing, the text width is liable to change, which can cause a slow-feeling animation
++        // of the guardrail warning icon. Disable animations while editing.
++        return isEditing ? nil : .default
++    }
++    
++    private var warningColor: Color {
++        guard let value = value else {
++            return .primary
++        }
++        
++        guard isSupportedValue else { return guidanceColors.critical }
++        
++        switch guardrail.classification(for: value) {
++        case .withinRecommendedRange:
++            return isEditing ? .accentColor : guidanceColors.acceptable
++        case .outsideRecommendedRange(let threshold):
++            switch threshold {
++            case .minimum, .maximum:
++                return guidanceColors.critical
++            case .belowRecommended, .aboveRecommended:
++                return guidanceColors.warning
++            }
++        }
++    }
++}
++
++fileprivate extension AnyTransition {
++    static let springInDisappear = asymmetric(
++        insertion: AnyTransition.scale.animation(.spring(dampingFraction: 0.5)),
++        removal: .identity
++    )
++}
+diff --git a/LoopKit/LoopKitUI/Views/Preferences Editors/BasalLockEditor.swift b/LoopKit/LoopKitUI/Views/Preferences Editors/BasalLockEditor.swift
+new file mode 100644
+index 00000000..dc313a9c
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/Preferences Editors/BasalLockEditor.swift	
+@@ -0,0 +1,209 @@
++//
++//  BasalLockEditor.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import SwiftUI
++import HealthKit
++import LoopKit
++
++public struct BasalLockEditor: View {
++    @EnvironmentObject private var displayGlucosePreference: DisplayGlucosePreference
++    
++    @Environment(\.dismissAction) var dismiss
++    @Environment(\.authenticate) var authenticate
++    @Environment(\.appName) private var appName
++    
++    let viewModel: PreferencesViewModel
++    let didSave: (() -> Void)?
++    
++    @State private var userDidTap: Bool = false
++    @State private var isBasalLockEnabled: Bool
++    @State private var threshold: HKQuantity
++    @State private var isEditing = false
++    @State private var showingConfirmationAlert = false
++    
++    private var initialValue: HKQuantity {
++        viewModel.basalLockThreshold
++    }
++    
++    public init(preferencesViewModel: PreferencesViewModel, didSave: (() -> Void)? = nil) {
++        self.viewModel = preferencesViewModel
++        self._isBasalLockEnabled = State(initialValue: preferencesViewModel.isBasalLockEnabled)
++        self._threshold = State(initialValue: preferencesViewModel.basalLockThreshold)
++        self.didSave = didSave
++    }
++    
++    public var body: some View {
++        contentWithCancel
++            .navigationBarTitle("", displayMode: .inline)
++    }
++    
++    private var contentWithCancel: some View {
++        content
++            .navigationBarBackButtonHidden(isBasalLockEnabled != viewModel.isBasalLockEnabled || threshold != viewModel.basalLockThreshold)
++            .toolbar {
++                ToolbarItem(placement: .navigationBarLeading) {
++                    leadingNavigationBarItem
++                }
++            }
++    }
++    
++    @ViewBuilder
++    private var leadingNavigationBarItem: some View {
++        if isBasalLockEnabled != viewModel.isBasalLockEnabled || threshold != viewModel.basalLockThreshold {
++            cancelButton
++        } else {
++            EmptyView()
++        }
++    }
++    
++    private var cancelButton: some View {
++        Button(action: { self.dismiss() }) {
++            Text(LocalizedString("Cancel", comment: "Cancel editing settings button title"))
++        }
++    }
++    
++    private var picker: GlucoseValuePicker {
++        GlucoseValuePicker(
++            value: self.$threshold.animation(),
++            unit: displayGlucosePreference.unit,
++            guardrail: .basalLockThreshold,
++            bounds: Guardrail.basalLockThreshold.absoluteBounds.lowerBound...Guardrail.basalLockThreshold.absoluteBounds.upperBound
++        )
++    }
++    
++    private var content: some View {
++        ConfigurationPage(
++            title: Text(LocalizedString("Basal Lock Threshold", comment: "Title for basal lock threshold setting")),
++            actionButtonTitle: Text(LocalizedString("Save", comment: "Save button title")),
++            actionButtonState: saveButtonState,
++            cards: {
++                Card {
++                    description
++                        .font(.callout)
++                        .foregroundColor(Color(.secondaryLabel))
++                        .fixedSize(horizontal: false, vertical: true)
++                    
++                    Toggle(isOn: $isBasalLockEnabled) {
++                        Text("Enable Basal Lock")
++                    }
++                    .animation(.default, value: isBasalLockEnabled)
++                    
++                    ExpandableSetting(
++                        isEditing: $isEditing,
++                        valueContent: {
++                            GuardrailConstrainedQuantityView(
++                                value: threshold,
++                                unit: displayGlucosePreference.unit,
++                                guardrail: .basalLockThreshold,
++                                isEditing: isEditing,
++                                // Workaround for strange animation behavior on appearance
++                                forceDisableAnimations: true
++                            )
++                        },
++                        expandedContent: {
++                            // Prevent the picker from expanding the card's width on small devices
++                            picker.frame(maxWidth: 200)
++                        }
++                    )
++                    .transition(.slide)
++                }
++            },
++            actionAreaContent: {
++                instructionalContentIfNecessary
++                if isBasalLockEnabled && warningThreshold != nil && userDidTap {
++                    PreferencesGuardrailWarning(preferencesSetting: .basalLock, title: basalLockTitle, threshold: warningThreshold!)
++                        .transition(.slide)
++                }
++            },
++            action: {
++                if self.warningThreshold == nil {
++                    self.startSaving()
++                } else {
++                    self.showingConfirmationAlert = true
++                }
++            }
++        )
++        .alert(isPresented: $showingConfirmationAlert, content: confirmationAlert)
++        .simultaneousGesture(TapGesture().onEnded {
++            withAnimation {
++                self.userDidTap = true
++            }
++        })
++    }
++    
++    private var basalLockTitle: Text {
++        Text(LocalizedString("Basal Lock Threshold", comment: "Title for basal lock threshold setting"))
++    }
++    
++    private var description: Text {
++        Text(LocalizedString("Basal Lock prevents the basal rate from being throttled if the blood glucose is above a certain level.", comment: "Description for basal lock threshold setting"))
++    }
++    
++    private var instructionalContentIfNecessary: some View {
++        Group {
++            if !userDidTap {
++                instructionalContent
++            }
++        }
++    }
++    
++    private var instructionalContent: some View {
++        HStack {
++            Text(LocalizedString("You can edit the setting by tapping into the line item.", comment: "Description of how to edit setting"))
++                .foregroundColor(.secondary)
++                .font(.subheadline)
++            Spacer()
++        }
++    }
++    
++    private var saveButtonState: ConfigurationPageActionButtonState {
++        let selectableValues = picker.selectableValues
++        let adjustedBounds = (selectableValues.first!)...(selectableValues.last!)
++        guard adjustedBounds.contains(threshold.doubleValue(for: displayGlucosePreference.unit)) else {
++            return .disabled
++        }
++        return (isBasalLockEnabled != viewModel.isBasalLockEnabled || threshold != viewModel.basalLockThreshold) ? .enabled : .disabled
++    }
++    
++    private var warningThreshold: SafetyClassification.Threshold? {
++        switch Guardrail.basalLockThreshold.classification(for: threshold) {
++        case .withinRecommendedRange:
++            return nil
++        case .outsideRecommendedRange(let threshold):
++            return threshold
++        }
++    }
++    
++    private func confirmationAlert() -> SwiftUI.Alert {
++        SwiftUI.Alert(
++            title: Text(LocalizedString("Save Basal Lock Threshold?", comment: "Alert title for confirming a basal lock threshold outside the recommended range")),
++            message: Text(LocalizedString("Your setting for basal lock is outside the recommended range.", comment: "Descriptive text for saving settings outside the recommended range for basal lock")),
++            primaryButton: .cancel(Text(LocalizedString("Go Back", comment: "Text for go back action on confirmation alert"))),
++            secondaryButton: .default(
++                Text(LocalizedString("Continue", comment: "Text for continue action on confirmation alert")),
++                action: startSaving
++            )
++        )
++    }
++    
++    private func startSaving() {
++        authenticate(LocalizedString("Authentication is required to save this setting.", comment: "Authentication challenge description for basal lock threshold")) {
++            switch $0 {
++            case .success: self.continueSaving()
++            case .failure: break
++            }
++        }
++    }
++    
++    private func continueSaving() {
++        viewModel.updateBasalLockEnabled(self.isBasalLockEnabled)
++        viewModel.updateBasalLockThreshold(self.threshold)
++        didSave?()
++        self.dismiss()
++    }
++}
+diff --git a/LoopKit/LoopKitUI/Views/Preferences Editors/PreferencesGuardrailWarning.swift b/LoopKit/LoopKitUI/Views/Preferences Editors/PreferencesGuardrailWarning.swift
+new file mode 100644
+index 00000000..3a7dd0ad
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/Preferences Editors/PreferencesGuardrailWarning.swift	
+@@ -0,0 +1,101 @@
++//
++//  PreferencesGuardrailWarning.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import SwiftUI
++import LoopKit
++
++public struct PreferencesGuardrailWarning: View {
++    private enum CrossedThresholds {
++        case one(SafetyClassification.Threshold)
++        case oneOrMore([SafetyClassification.Threshold])
++    }
++    
++    private var title: Text
++    private var crossedThresholds: CrossedThresholds
++    private var captionOverride: Text?
++    private var preferencesSetting: PreferencesSetting
++    
++    public init(
++        preferencesSetting: PreferencesSetting,
++        title: Text,
++        threshold: SafetyClassification.Threshold,
++        caption: Text? = nil
++    ) {
++        self.preferencesSetting = preferencesSetting
++        self.title = title
++        self.crossedThresholds = .one(threshold)
++        self.captionOverride = caption
++    }
++    
++    public init(
++        preferencesSetting: PreferencesSetting,
++        title: Text,
++        thresholds: [SafetyClassification.Threshold],
++        caption: Text? = nil
++    ) {
++        precondition(!thresholds.isEmpty)
++        self.preferencesSetting = preferencesSetting
++        self.title = title
++        self.crossedThresholds = .oneOrMore(thresholds)
++        self.captionOverride = caption
++    }
++    
++    public var body: some View {
++        WarningView(title: title, caption: caption, severity: severity)
++    }
++    
++    private var severity: WarningSeverity {
++        switch crossedThresholds {
++        case .one(let threshold):
++            return threshold.severity
++        case .oneOrMore(let thresholds):
++            return thresholds.lazy.map({ $0.severity }).max()!
++        }
++    }
++    
++    private var caption: Text {
++        if let caption = captionOverride {
++            return caption
++        }
++        
++        switch crossedThresholds {
++        case .one(let threshold):
++            return captionForThreshold(threshold)
++        case .oneOrMore(let thresholds):
++            if thresholds.count == 1, let threshold = thresholds.first {
++                return captionForThreshold(threshold)
++            } else {
++                return captionForThresholds()
++            }
++        }
++    }
++    
++    private func captionForThreshold(_ threshold: SafetyClassification.Threshold) -> Text {
++        switch threshold {
++        case .minimum, .belowRecommended:
++            return Text(preferencesSetting.guardrailCaptionForLowValue)
++        case .aboveRecommended, .maximum:
++            return Text(preferencesSetting.guardrailCaptionForHighValue)
++        }
++    }
++    
++    private func captionForThresholds() -> Text {
++        return Text(preferencesSetting.guardrailCaptionForOutsideValues)
++    }
++}
++
++fileprivate extension SafetyClassification.Threshold {
++    var severity: WarningSeverity {
++        switch self {
++        case .belowRecommended, .aboveRecommended:
++            return .default
++        case .minimum, .maximum:
++            return .critical
++        }
++    }
++}
+diff --git a/LoopKit/LoopKitUI/Views/Preferences Editors/PreferencesView.swift b/LoopKit/LoopKitUI/Views/Preferences Editors/PreferencesView.swift
+new file mode 100644
+index 00000000..41476c35
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/Preferences Editors/PreferencesView.swift	
+@@ -0,0 +1,141 @@
++//
++//  PreferencesView.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import SwiftUI
++import LoopKit
++import HealthKit
++
++public struct PreferencesView: View {
++    @Environment(\.dismissAction) private var dismiss
++    @Environment(\.appName) private var appName
++    @EnvironmentObject var displayGlucosePreference: DisplayGlucosePreference
++    
++    @ObservedObject var viewModel: PreferencesViewModel
++    
++    public init(viewModel: PreferencesViewModel) {
++        self.viewModel = viewModel
++    }
++    
++    private static func createFormatter(for unit: HKUnit) -> NumberFormatter {
++        let quantityFormatter = QuantityFormatter(for: unit)
++        return quantityFormatter.numberFormatter
++    }
++    
++    public var body: some View {
++        navigationViewWrappedContent
++    }
++    
++    private var formatter: NumberFormatter {
++        let quantityFormatter = QuantityFormatter(for: displayGlucosePreference.unit)
++        return quantityFormatter.numberFormatter
++    }
++}
++
++extension PreferencesView {
++    private var navigationViewWrappedContent: some View {
++        NavigationView {
++            ZStack {
++                Color(.systemGroupedBackground)
++                    .edgesIgnoringSafeArea(.all)
++                content
++                    .toolbar {
++                        ToolbarItem(placement: .navigationBarTrailing) {
++                            dismissButton
++                        }
++                    }
++                    .navigationBarTitle(preferencesTitle, displayMode: .large)
++            }
++        }
++    }
++    
++    private var dismissButton: some View {
++        Button(action: dismiss) {
++            Text("Done")
++        }
++    }
++    
++    private var preferencesTitle: String {
++        return "Preferences"
++    }
++    
++    private var content: some View {
++        CardList(title: nil, style: .sectioned(cardListSections)) //, trailer: cardListTrailer
++    }
++    
++    private var cardListSections: [CardListSection] {
++        var cardListSections: [CardListSection] = []
++        
++        cardListSections.append(preferencesCardListSection)
++        
++        return cardListSections
++    }
++    
++    private var preferencesCardListSection: CardListSection {
++        CardListSection {
++            preferencesCardStack
++                .spacing(20)
++        }
++    }
++    
++    private var preferencesCardStack: CardStack {
++        var cards: [Card] = []
++        
++        cards.append(basalLockSection)
++        
++        return CardStack(cards: cards)
++    }
++    
++    @ViewBuilder
++    func screen(for setting: PreferencesSetting, dismiss: @escaping () -> Void) -> some View {
++        switch setting {
++        case .basalLock:
++            BasalLockEditor(preferencesViewModel: viewModel, didSave: dismiss)
++        }
++    }
++    
++    private func card<Content>(for preferencesSetting: PreferencesSetting, @ViewBuilder content: @escaping () -> Content) -> Card where Content: View {
++        Card {
++            SectionWithTapToEdit(
++                isEnabled: true,
++                title: preferencesSetting.title,
++                descriptiveText: preferencesSetting.descriptiveText(appName: appName),
++                destination: { dismiss in
++                    screen(for: preferencesSetting, dismiss: dismiss)
++                        .environment(\.dismissAction, dismiss)
++                },
++                content: content
++            )
++        }
++    }
++    
++    private var basalLockSection: Card {
++        card(for: .basalLock) {
++            SectionDivider()
++            HStack {
++                Spacer()
++                if viewModel.isBasalLockEnabled {
++                    HStack(alignment: .firstTextBaseline) {
++                        Text(formatter.string(for: viewModel.basalLockThreshold.doubleValue(for: displayGlucosePreference.unit)) ?? "")
++                        Text(displayGlucosePreference.unit.shortLocalizedUnitString())
++                            .foregroundColor(Color(.secondaryLabel))
++                    }
++                } else {
++                    Text("Off")
++                        .foregroundColor(Color(.secondaryLabel))
++                }
++            }
++        }
++    }
++}
++
++fileprivate struct SectionDivider: View {
++    var body: some View {
++        Divider()
++            .padding(.trailing, -16)
++    }
++}

--- a/basal_lock/dev377_basal_lock_profiles.patch
+++ b/basal_lock/dev377_basal_lock_profiles.patch
@@ -1,0 +1,1193 @@
+Submodule Loop 674d123..c484fe7:
+diff --git a/Loop/Loop.xcodeproj/project.pbxproj b/Loop/Loop.xcodeproj/project.pbxproj
+index 11819516..a22646b3 100644
+--- a/Loop/Loop.xcodeproj/project.pbxproj
++++ b/Loop/Loop.xcodeproj/project.pbxproj
+@@ -489,6 +489,7 @@
+ 		C1FB428F217921D600FAB378 /* PumpManagerUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FB428E217921D600FAB378 /* PumpManagerUI.swift */; };
+ 		C1FB4290217922A100FAB378 /* PumpManagerUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FB428E217921D600FAB378 /* PumpManagerUI.swift */; };
+ 		DD3DBD292A33AFE9000F8B5B /* IntegralRetrospectiveCorrectionSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3DBD282A33AFE9000F8B5B /* IntegralRetrospectiveCorrectionSelectionView.swift */; };
++		DDC065142B65871E0033FD88 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC065132B65871E0033FD88 /* Preferences.swift */; };
+ 		DDC389F62A2B61750066E2E8 /* ApplicationFactorStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC389F52A2B61750066E2E8 /* ApplicationFactorStrategy.swift */; };
+ 		DDC389F82A2B620B0066E2E8 /* GlucoseBasedApplicationFactorStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC389F72A2B620B0066E2E8 /* GlucoseBasedApplicationFactorStrategy.swift */; };
+ 		DDC389FA2A2B62470066E2E8 /* ConstantApplicationFactorStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC389F92A2B62470066E2E8 /* ConstantApplicationFactorStrategy.swift */; };
+@@ -1292,6 +1293,7 @@
+ 		C1FB428B217806A300FAB378 /* StateColorPalette.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateColorPalette.swift; sourceTree = "<group>"; };
+ 		C1FB428E217921D600FAB378 /* PumpManagerUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PumpManagerUI.swift; sourceTree = "<group>"; };
+ 		DD3DBD282A33AFE9000F8B5B /* IntegralRetrospectiveCorrectionSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegralRetrospectiveCorrectionSelectionView.swift; sourceTree = "<group>"; };
++		DDC065132B65871E0033FD88 /* Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
+ 		DDC389F52A2B61750066E2E8 /* ApplicationFactorStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationFactorStrategy.swift; sourceTree = "<group>"; };
+ 		DDC389F72A2B620B0066E2E8 /* GlucoseBasedApplicationFactorStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseBasedApplicationFactorStrategy.swift; sourceTree = "<group>"; };
+ 		DDC389F92A2B62470066E2E8 /* ConstantApplicationFactorStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantApplicationFactorStrategy.swift; sourceTree = "<group>"; };
+@@ -1960,6 +1962,7 @@
+ 				C1E3862428247B7100F561A4 /* StoredLoopNotRunningNotification.swift */,
+ 				4328E0311CFC068900E199AA /* WatchContext+LoopKit.swift */,
+ 				A987CD4824A58A0100439ADC /* ZipArchive.swift */,
++				DDC065132B65871E0033FD88 /* Preferences.swift */,
+ 			);
+ 			path = Models;
+ 			sourceTree = "<group>";
+@@ -3742,6 +3745,7 @@
+ 				E98A55EF24EDD6E60008715D /* DosingDecisionStoreProtocol.swift in Sources */,
+ 				B4001CEE28CBBC82002FB414 /* AlertManagementView.swift in Sources */,
+ 				E9C00EF524C623EF00628F35 /* LoopSettings+Loop.swift in Sources */,
++				DDC065142B65871E0033FD88 /* Preferences.swift in Sources */,
+ 				4389916B1E91B689000EEF90 /* ChartSettings+Loop.swift in Sources */,
+ 				C178249A1E1999FA00D9D25C /* CaseCountable.swift in Sources */,
+ 				B4F3D25124AF890C0095CE44 /* BluetoothStateManager.swift in Sources */,
+diff --git a/Loop/Loop/Managers/LoopDataManager.swift b/Loop/Loop/Managers/LoopDataManager.swift
+index 63164e69..f6accc52 100644
+--- a/Loop/Loop/Managers/LoopDataManager.swift
++++ b/Loop/Loop/Managers/LoopDataManager.swift
+@@ -1553,7 +1553,8 @@ extension LoopDataManager {
+             model: model,
+             pendingInsulin: 0, // Pending insulin is already reflected in the prediction
+             maxBolus: maxBolus,
+-            volumeRounder: volumeRounder
++            volumeRounder: volumeRounder,
++            preferences: Preferences.shared
+         )
+     }
+ 
+@@ -1836,7 +1837,8 @@ extension LoopDataManager {
+                     lastTempBasal: lastTempBasal,
+                     volumeRounder: volumeRounder,
+                     rateRounder: rateRounder,
+-                    isBasalRateScheduleOverrideActive: settings.scheduleOverride?.isBasalRateScheduleOverriden(at: startDate) == true
++                    isBasalRateScheduleOverrideActive: settings.scheduleOverride?.isBasalRateScheduleOverriden(at: startDate) == true,
++                    preferences: Preferences.shared
+                 )
+             case .tempBasalOnly:
+ 
+@@ -1851,7 +1853,8 @@ extension LoopDataManager {
+                     additionalActiveInsulinClamp: iobHeadroom,
+                     lastTempBasal: lastTempBasal,
+                     rateRounder: rateRounder,
+-                    isBasalRateScheduleOverrideActive: settings.scheduleOverride?.isBasalRateScheduleOverriden(at: startDate) == true
++                    isBasalRateScheduleOverrideActive: settings.scheduleOverride?.isBasalRateScheduleOverriden(at: startDate) == true,
++                    preferences: Preferences.shared
+                 )
+                 dosingRecommendation = AutomaticDoseRecommendation(basalAdjustment: temp)
+             }
+diff --git a/Loop/Loop/Models/Preferences.swift b/Loop/Loop/Models/Preferences.swift
+new file mode 100644
+index 00000000..dc9150f8
+--- /dev/null
++++ b/Loop/Loop/Models/Preferences.swift
+@@ -0,0 +1,50 @@
++//
++//  Preferences.swift
++//  Loop
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import LoopKit
++import HealthKit
++
++struct Preferences: PreferencesProvider {
++    
++    static var shared = Preferences()
++    
++    private init() {}
++    
++    // Basal Lock Threshold
++    var basalLockThreshold: HKQuantity {
++        get {
++            let key = "basalLockThreshold"
++            if let value = UserDefaults.standard.value(forKey: key) as? Double {
++                return HKQuantity(unit: .milligramsPerDeciliter, doubleValue: value)
++            } else {
++                return HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 250)
++            }
++        }
++        set {
++            let key = "basalLockThreshold"
++            let value = newValue.doubleValue(for: .milligramsPerDeciliter)
++            UserDefaults.standard.set(value, forKey: key)
++        }
++    }
++    
++    // Basal Lock Enabled
++    var isBasalLockEnabled: Bool {
++        get {
++            let key = "isBasalLockEnabled"
++            if UserDefaults.standard.object(forKey: key) == nil {
++                return false
++            }
++            return UserDefaults.standard.bool(forKey: key)
++        }
++        set {
++            let key = "isBasalLockEnabled"
++            UserDefaults.standard.set(newValue, forKey: key)
++        }
++    }
++}
+diff --git a/Loop/Loop/Views/SettingsView.swift b/Loop/Loop/Views/SettingsView.swift
+index 74045900..f2a41195 100644
+--- a/Loop/Loop/Views/SettingsView.swift
++++ b/Loop/Loop/Views/SettingsView.swift
+@@ -51,6 +51,7 @@ public struct SettingsView: View {
+             
+             case favoriteFoods
+             case therapySettings
++            case preferences
+             case profiles
+         }
+     }
+@@ -86,6 +87,9 @@ public struct SettingsView: View {
+                     if FeatureFlags.allowExperimentalFeatures {
+                         favoriteFoodsSection
+                     }
++                    if FeatureFlags.allowExperimentalFeatures {
++                        preferencesSection
++                    }
+                     if (viewModel.pumpManagerSettingsViewModel.isTestingDevice || viewModel.cgmManagerSettingsViewModel.isTestingDevice) && viewModel.showDeleteTestData {
+                         deleteDataSection
+                     }
+@@ -158,6 +162,8 @@ public struct SettingsView: View {
+                     .environment(\.insulinTintColor, self.insulinTintColor)
+                 case .favoriteFoods:
+                     FavoriteFoodsView()
++                case .preferences:
++                    PreferencesView(viewModel: PreferencesViewModel(preferencesProvider: Preferences.shared)).environmentObject(displayGlucosePreference)
+                 case .profiles:
+                     ProfileView(viewModel: ProfileViewModel(therapySettings: self.viewModel.therapySettings(),
+                                                             sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
+@@ -392,6 +398,16 @@ extension SettingsView {
+         }
+     }
+     
++    private var preferencesSection: some View {
++        Section {
++            LargeButton(action: { sheet = .preferences },
++                        includeArrow: true,
++                        imageView: AnyView(Image(systemName: "gearshape.fill").font(.system(size: 30, weight: .bold))),
++                        label: NSLocalizedString("Preferences", comment: "Title text for button to Preferences"),
++                        descriptiveText: NSLocalizedString("Customize your Loop experience by adjusting additional settings", comment: "Descriptive text for Preferences"))
++        }
++    }
++
+     private var cgmChoices: [ActionSheet.Button] {
+         var result = viewModel.cgmManagerSettingsViewModel.availableDevices
+             .sorted(by: {$0.localizedTitle < $1.localizedTitle})
+Submodule LoopKit 77793ca..c6d1a1a:
+diff --git a/LoopKit/LoopKit.xcodeproj/project.pbxproj b/LoopKit/LoopKit.xcodeproj/project.pbxproj
+index eec949bd..7ec12a27 100644
+--- a/LoopKit/LoopKit.xcodeproj/project.pbxproj
++++ b/LoopKit/LoopKit.xcodeproj/project.pbxproj
+@@ -869,6 +869,13 @@
+ 		DDAF746729F422C600719F0A /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAF746629F422C600719F0A /* ProfileView.swift */; };
+ 		DDAF746929F4234000719F0A /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAF746829F4234000719F0A /* ProfileViewModel.swift */; };
+ 		DDCFC91E2AA9F702003DE656 /* RenameProfileEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCFC91D2AA9F702003DE656 /* RenameProfileEditor.swift */; };
++		DD13BC702C3C71A70062313B /* BasalLockEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD13BC6F2C3C71A70062313B /* BasalLockEditor.swift */; };
++		DD13BC722C3C74CD0062313B /* PreferencesGuardrailWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD13BC712C3C74CD0062313B /* PreferencesGuardrailWarning.swift */; };
++		DD28B3712B80C074001044D4 /* PreferencesSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD28B3702B80C074001044D4 /* PreferencesSetting.swift */; };
++		DD545A5B2B80ECB900915F95 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD545A5A2B80ECB900915F95 /* PreferencesView.swift */; };
++		DD545A5F2B80EFA900915F95 /* PreferencesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD545A5E2B80EFA900915F95 /* PreferencesViewModel.swift */; };
++		DD545A652B814CA800915F95 /* PreferencesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD545A642B814CA800915F95 /* PreferencesProvider.swift */; };
++		DD545A692B8BCF8E00915F95 /* Guardrail+Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD545A682B8BCF8E00915F95 /* Guardrail+Preferences.swift */; };
+ 		E9077D2724ACD59F0066A88D /* InformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9077D2624ACD59F0066A88D /* InformationView.swift */; };
+ 		E9077D2A24ACDE2C0066A88D /* CorrectionRangeInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9077D2924ACDE2C0066A88D /* CorrectionRangeInformationView.swift */; };
+ 		E9086B2924B39EDC0062F5C8 /* ChartsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B2824B39EDC0062F5C8 /* ChartsTableViewController.swift */; };
+@@ -1933,6 +1940,13 @@
+ 		DDAF746629F422C600719F0A /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+ 		DDAF746829F4234000719F0A /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
+ 		DDCFC91D2AA9F702003DE656 /* RenameProfileEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameProfileEditor.swift; sourceTree = "<group>"; };
++		DD13BC6F2C3C71A70062313B /* BasalLockEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasalLockEditor.swift; sourceTree = "<group>"; };
++		DD13BC712C3C74CD0062313B /* PreferencesGuardrailWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesGuardrailWarning.swift; sourceTree = "<group>"; };
++		DD28B3702B80C074001044D4 /* PreferencesSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesSetting.swift; sourceTree = "<group>"; };
++		DD545A5A2B80ECB900915F95 /* PreferencesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
++		DD545A5E2B80EFA900915F95 /* PreferencesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesViewModel.swift; sourceTree = "<group>"; };
++		DD545A642B814CA800915F95 /* PreferencesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesProvider.swift; sourceTree = "<group>"; };
++		DD545A682B8BCF8E00915F95 /* Guardrail+Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Guardrail+Preferences.swift"; sourceTree = "<group>"; };
+ 		E9077D2624ACD59F0066A88D /* InformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationView.swift; sourceTree = "<group>"; };
+ 		E9077D2924ACDE2C0066A88D /* CorrectionRangeInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeInformationView.swift; sourceTree = "<group>"; };
+ 		E9086B2824B39EDC0062F5C8 /* ChartsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartsTableViewController.swift; sourceTree = "<group>"; };
+@@ -2283,6 +2297,7 @@
+ 		4369F090208B0D68000E3E45 /* Views */ = {
+ 			isa = PBXGroup;
+ 			children = (
++				DD545A592B80EC9500915F95 /* Preferences Editors */,
+ 				B4C004B2241085DB00B40429 /* ActionButton.swift */,
+ 				89AF78C524482268002B4FCC /* ActionButtonStyle.swift */,
+ 				C1E4B307242E995200E70CCB /* ActivityIndicator.swift */,
+@@ -2453,6 +2468,7 @@
+ 				C187338229B9486200519CDF /* TimeInterval.swift */,
+ 				C187339629B9488300519CDF /* TimeZone.swift */,
+ 				C187339729B9488300519CDF /* UUID.swift */,
++				DD545A682B8BCF8E00915F95 /* Guardrail+Preferences.swift */,
+ 			);
+ 			path = Extensions;
+ 			sourceTree = "<group>";
+@@ -2661,6 +2677,8 @@
+ 				C1814B8B226371DF008D2D8E /* WeakSynchronizedDelegate.swift */,
+ 				43CACE0D2247F89100F90AF5 /* WeakSynchronizedSet.swift */,
+ 				B4A2ABEE2AAB5160007E3EC1 /* Pluggable.swift */,
++				DD28B3702B80C074001044D4 /* PreferencesSetting.swift */,
++				DD545A642B814CA800915F95 /* PreferencesProvider.swift */,
+ 			);
+ 			path = LoopKit;
+ 			sourceTree = "<group>";
+@@ -3182,6 +3200,7 @@
+ 				B455F48025FF9A8B000ED456 /* InsulinSensitivityScheduleEditorViewModel.swift */,
+ 				B455F2A125FBE985000ED456 /* SuspendThresholdEditorViewModel.swift */,
+ 				1D1FCE2424BD42EF000300A8 /* TherapySettingsViewModel.swift */,
++				DD545A5E2B80EFA900915F95 /* PreferencesViewModel.swift */,
+ 				DD508E052A17712D00EEF8FD /* ProfileViewModel+FileManagement.swift */,
+ 			);
+ 			path = ViewModels;
+@@ -3308,6 +3327,16 @@
+ 			path = LoopAlgorithm;
+ 			sourceTree = "<group>";
+ 		};
++		DD545A592B80EC9500915F95 /* Preferences Editors */ = {
++			isa = PBXGroup;
++			children = (
++				DD545A5A2B80ECB900915F95 /* PreferencesView.swift */,
++				DD13BC6F2C3C71A70062313B /* BasalLockEditor.swift */,
++				DD13BC712C3C74CD0062313B /* PreferencesGuardrailWarning.swift */,
++			);
++			path = "Preferences Editors";
++			sourceTree = "<group>";
++		};
+ 		E9077D2824ACD5AA0066A88D /* Information Screens */ = {
+ 			isa = PBXGroup;
+ 			children = (
+@@ -4070,6 +4099,7 @@
+ 				B4A2AAB1240830A30066563F /* LabeledTextField.swift in Sources */,
+ 				A9D3FF0B2A6C198C000C891D /* CGPoint.swift in Sources */,
+ 				B429D66E24BF7255003E1B4A /* UIImage.swift in Sources */,
++				DD13BC722C3C74CD0062313B /* PreferencesGuardrailWarning.swift in Sources */,
+ 				B46B62A923FF05F8001E69BA /* LabeledNumberInput.swift in Sources */,
+ 				892155152245C57E009112BC /* SegmentedGaugeBarLayer.swift in Sources */,
+ 				C1DD512B259FD8A600DE27AE /* InsulinTypeChooser.swift in Sources */,
+@@ -4107,6 +4137,7 @@
+ 				A9D3FF042A6C1944000C891D /* PredictedGlucoseChart.swift in Sources */,
+ 				C1DE4C2125A253BD007065F8 /* Color.swift in Sources */,
+ 				898E6E702241EDB70019E459 /* PercentageTextFieldTableViewController.swift in Sources */,
++				DD13BC702C3C71A70062313B /* BasalLockEditor.swift in Sources */,
+ 				89CAB36D24C9EC98009EE3CE /* Keyboard.swift in Sources */,
+ 				89186C0724BF7FC70003D0F3 /* Guardrail+UI.swift in Sources */,
+ 				43FB60E520DCBA02002B996B /* SetupTableViewController.swift in Sources */,
+@@ -4159,6 +4190,7 @@
+ 				B46B62B323FF0E62001E69BA /* SelectableLabel.swift in Sources */,
+ 				89FC6893245A2D680075CF59 /* ScheduleItemView.swift in Sources */,
+ 				43BA716F201E49220058961E /* FoodEmojiDataSource.swift in Sources */,
++				DD545A5F2B80EFA900915F95 /* PreferencesViewModel.swift in Sources */,
+ 				E9077D2724ACD59F0066A88D /* InformationView.swift in Sources */,
+ 				E94141D024C8F31C0096C326 /* DeliveryLimitsEditor.swift in Sources */,
+ 				1452F4BA2A85266500F8B9E4 /* CarbQuantityRow.swift in Sources */,
+@@ -4223,6 +4255,7 @@
+ 				43BA717D201EE7090058961E /* GlucoseRangeTableViewCell.swift in Sources */,
+ 				B455F3A425FF7FF0000ED456 /* CorrectionRangeOverridesEditorViewModel.swift in Sources */,
+ 				A9D3FF002A6C1944000C891D /* ChartConstants.swift in Sources */,
++				DD545A5B2B80ECB900915F95 /* PreferencesView.swift in Sources */,
+ 				89BE75CB2464BC2000B145D9 /* AlertContent.swift in Sources */,
+ 				43BA7184201EE7090058961E /* TextFieldTableViewController.swift in Sources */,
+ 				1452F4B22A8521CD00F8B9E4 /* TextFieldRow.swift in Sources */,
+@@ -4312,6 +4345,7 @@
+ 				89AE222F228BC68000BDFD85 /* DoseProgressTimerEstimator.swift in Sources */,
+ 				43D8FDF61C7290350073BE78 /* DailyQuantitySchedule.swift in Sources */,
+ 				43D8FDF51C7290350073BE78 /* CarbRatioSchedule.swift in Sources */,
++				DD545A652B814CA800915F95 /* PreferencesProvider.swift in Sources */,
+ 				4322B76F202FA26F0002837D /* GlucoseSampleValue.swift in Sources */,
+ 				89AE222C228BC66E00BDFD85 /* Locked.swift in Sources */,
+ 				432CF87120D76D5A0066B889 /* GlucoseDisplayable.swift in Sources */,
+@@ -4381,6 +4415,7 @@
+ 				A93761C125ED670200F6BE43 /* BluetoothProvider.swift in Sources */,
+ 				433BC7A720523DB7000B1200 /* NewGlucoseSample.swift in Sources */,
+ 				4322B78E202FA2B30002837D /* InsulinMath.swift in Sources */,
++				DD28B3712B80C074001044D4 /* PreferencesSetting.swift in Sources */,
+ 				C17F39D023CE34B100FA1113 /* StoredDeviceLogEntry.swift in Sources */,
+ 				43B17C89208EEC0B00AC27E9 /* HealthStoreUnitCache.swift in Sources */,
+ 				A912BE29245B9CD500CBE199 /* SettingsObject+CoreDataClass.swift in Sources */,
+@@ -4407,6 +4442,7 @@
+ 				A932803B2798D63B0091D0A1 /* SyncAlertObject.swift in Sources */,
+ 				1D841AAD24577EE10069DBFF /* AlertSoundPlayer.swift in Sources */,
+ 				C19E776B2A61FD8A003F06C5 /* RetrospectiveCorrection.swift in Sources */,
++				DD545A692B8BCF8E00915F95 /* Guardrail+Preferences.swift in Sources */,
+ 				C187339A29B9488300519CDF /* UUID.swift in Sources */,
+ 				C1CAB9E926A3254800A57273 /* StoredInsulinModel.swift in Sources */,
+ 				43CACE0E2247F89100F90AF5 /* WeakSynchronizedSet.swift in Sources */,
+diff --git a/LoopKit/LoopKit/Extensions/Guardrail+Preferences.swift b/LoopKit/LoopKit/Extensions/Guardrail+Preferences.swift
+new file mode 100644
+index 00000000..e413f7b5
+--- /dev/null
++++ b/LoopKit/LoopKit/Extensions/Guardrail+Preferences.swift
+@@ -0,0 +1,18 @@
++//
++//  Guardrail+Preferences.swift
++//  LoopKit
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import HealthKit
++
++public extension Guardrail where Value == HKQuantity {
++    static let basalLockThreshold = Guardrail(
++        absoluteBounds: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 200)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 300),
++        recommendedBounds: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 220)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 300),
++        startingSuggestion: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 250)
++    )
++}
+diff --git a/LoopKit/LoopKit/LoopAlgorithm/DoseMath.swift b/LoopKit/LoopKit/LoopAlgorithm/DoseMath.swift
+index f4b8d44a..1151ff12 100644
+--- a/LoopKit/LoopKit/LoopAlgorithm/DoseMath.swift
++++ b/LoopKit/LoopKit/LoopAlgorithm/DoseMath.swift
+@@ -231,7 +231,8 @@ extension Collection where Element: GlucoseValue {
+         at date: Date,
+         suspendThreshold: HKQuantity,
+         sensitivity: HKQuantity,
+-        model: InsulinModel
++        model: InsulinModel,
++        preferences: PreferencesProvider
+     ) -> InsulinCorrection? {
+         let effectDuration = model.effectDuration
+         let timeline = [AbsoluteScheduleValue(startDate: date, endDate: date.addingTimeInterval(effectDuration), value: sensitivity)]
+@@ -240,7 +241,8 @@ extension Collection where Element: GlucoseValue {
+             at: date,
+             suspendThreshold: suspendThreshold,
+             insulinSensitivityTimeline: timeline,
+-            model: model)
++            model: model,
++            preferences: preferences)
+     }
+ 
+     /// For a collection of glucose prediction, determine the least amount of insulin delivered at
+@@ -258,7 +260,8 @@ extension Collection where Element: GlucoseValue {
+         at date: Date,
+         suspendThreshold: HKQuantity,
+         insulinSensitivityTimeline: [AbsoluteScheduleValue<HKQuantity>],
+-        model: InsulinModel
++        model: InsulinModel,
++        preferences: PreferencesProvider
+     ) -> InsulinCorrection? {
+         var minGlucose: GlucoseValue?
+         var eventualGlucose: GlucoseValue?
+@@ -402,14 +405,16 @@ extension Collection where Element: GlucoseValue {
+         rateRounder: ((Double) -> Double)? = nil,
+         isBasalRateScheduleOverrideActive: Bool = false,
+         duration: TimeInterval = TimeInterval(30 * 60),
+-        continuationInterval: TimeInterval = TimeInterval(60 * 11)
++        continuationInterval: TimeInterval = TimeInterval(60 * 11),
++        preferences: PreferencesProvider
+     ) -> TempBasalRecommendation? {
+         let correction = self.insulinCorrection(
+             to: correctionRange,
+             at: date,
+             suspendThreshold: suspendThreshold ?? correctionRange.quantityRange(at: date).lowerBound,
+             sensitivity: sensitivity.quantity(at: date),
+-            model: model
++            model: model,
++            preferences: preferences
+         )
+ 
+         let scheduledBasalRate = basalRates.value(at: date)
+@@ -427,13 +432,22 @@ extension Collection where Element: GlucoseValue {
+             maxBasalRate = Swift.min(maxThirtyMinuteRateToKeepIOBBelowLimit, maxBasalRate)
+         }
+ 
+-        let temp = correction?.asTempBasal(
++        var temp = correction?.asTempBasal(
+             scheduledBasalRate: scheduledBasalRate,
+             maxBasalRate: maxBasalRate,
+             duration: duration,
+             rateRounder: rateRounder
+         )
+ 
++        if (preferences.isBasalLockEnabled && ( temp?.unitsPerHour ?? scheduledBasalRate < scheduledBasalRate  ||
++             lastTempBasal?.unitsPerHour ?? scheduledBasalRate < scheduledBasalRate
++             ) &&
++            self[0 as! Self.Index].quantity > preferences.basalLockThreshold)
++        {
++            print("####### Temp Basal Lock On #########")
++            temp = TempBasalRecommendation(unitsPerHour: scheduledBasalRate, duration: 1800)
++        }
++
+         return temp?.ifNecessary(
+             at: date,
+             scheduledBasalRate: scheduledBasalRate,
+@@ -475,14 +489,16 @@ extension Collection where Element: GlucoseValue {
+         rateRounder: ((Double) -> Double)? = nil,
+         isBasalRateScheduleOverrideActive: Bool = false,
+         duration: TimeInterval = TimeInterval(30 * 60),
+-        continuationInterval: TimeInterval = TimeInterval(11 * 60)
++        continuationInterval: TimeInterval = TimeInterval(11 * 60),
++        preferences: PreferencesProvider
+     ) -> AutomaticDoseRecommendation? {
+         guard let correction = self.insulinCorrection(
+             to: correctionRange,
+             at: date,
+             suspendThreshold: suspendThreshold ?? correctionRange.quantityRange(at: date).lowerBound,
+             sensitivity: sensitivity.quantity(at: date),
+-            model: model
++            model: model,
++            preferences: preferences
+         ) else {
+             return nil
+         }
+@@ -517,6 +533,15 @@ extension Collection where Element: GlucoseValue {
+             volumeRounder: volumeRounder
+         )
+ 
++        if (preferences.isBasalLockEnabled && (temp?.unitsPerHour ?? scheduledBasalRate < scheduledBasalRate ||
++              lastTempBasal?.unitsPerHour ?? scheduledBasalRate < scheduledBasalRate
++              ) &&
++            self[0 as! Self.Index].quantity > preferences.basalLockThreshold)
++        {
++            print("####### Temp Basal Lock On #########")
++            temp = TempBasalRecommendation(unitsPerHour: scheduledBasalRate, duration: 1800)
++        }
++
+         if temp != nil || bolusUnits > 0 {
+             return AutomaticDoseRecommendation(basalAdjustment: temp, bolusUnits: bolusUnits)
+         }
+@@ -545,14 +570,16 @@ extension Collection where Element: GlucoseValue {
+         model: InsulinModel,
+         pendingInsulin: Double,
+         maxBolus: Double,
+-        volumeRounder: ((Double) -> Double)? = nil
++        volumeRounder: ((Double) -> Double)? = nil,
++        preferences: PreferencesProvider
+     ) -> ManualBolusRecommendation {
+         guard let correction = self.insulinCorrection(
+             to: correctionRange,
+             at: date,
+             suspendThreshold: suspendThreshold ?? correctionRange.quantityRange(at: date).lowerBound,
+             sensitivity: sensitivity.quantity(at: date),
+-            model: model
++            model: model,
++            preferences: preferences
+         ) else {
+             return ManualBolusRecommendation(amount: 0, pendingInsulin: pendingInsulin)
+         }
+diff --git a/LoopKit/LoopKit/PreferencesProvider.swift b/LoopKit/LoopKit/PreferencesProvider.swift
+new file mode 100644
+index 00000000..a164defb
+--- /dev/null
++++ b/LoopKit/LoopKit/PreferencesProvider.swift
+@@ -0,0 +1,15 @@
++//
++//  PreferencesProvider.swift
++//  LoopKit
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import HealthKit
++
++public protocol PreferencesProvider {
++    var basalLockThreshold: HKQuantity { get set }
++    var isBasalLockEnabled: Bool { get set }
++}
+diff --git a/LoopKit/LoopKit/PreferencesSetting.swift b/LoopKit/LoopKit/PreferencesSetting.swift
+new file mode 100644
+index 00000000..0de6928d
+--- /dev/null
++++ b/LoopKit/LoopKit/PreferencesSetting.swift
+@@ -0,0 +1,60 @@
++//
++//  PreferencesSetting.swift
++//  LoopKit
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++
++public enum PreferencesSetting {
++    case basalLock
++}
++
++extension PreferencesSetting: Equatable { }
++
++public extension PreferencesSetting {
++    var title: String {
++        switch self {
++        case .basalLock:
++            return LocalizedString("Basal Lock", comment: "Title text for basal lock setting")
++        }
++    }
++    
++    var smallTitle: String {
++        return title
++    }
++    
++    func descriptiveText(appName: String) -> String {
++        switch self {
++        case .basalLock:
++            return String(format: LocalizedString("Basal Lock prevents the basal rate from being throttled if the blood glucose is above a certain level.", comment: "Descriptive text for basal lock (1: app name)"), appName)
++        }
++    }
++}
++
++// MARK: Guardrails
++public extension PreferencesSetting {
++    var guardrailCaptionForLowValue: String {
++        switch self {
++        case .basalLock:
++            return LocalizedString("The value you have entered is lower than what is typically recommended.", comment: "Descriptive text for guardrail low value warning for basal lock")
++        }
++    }
++    
++    var guardrailCaptionForHighValue: String {
++        switch self {
++        case .basalLock:
++            return LocalizedString("The value you have entered is higher than what is typically recommended.", comment: "Descriptive text for guardrail high value warning for basal lock")
++        }
++    }
++    
++    var guardrailCaptionForOutsideValues: String {
++        return LocalizedString("The value you have entered for Basal Lock is outside of the recommended range.", comment: "Descriptive text for guardrail outside value warning for basal lock")
++    }
++    
++    var guardrailSaveWarningCaption: String {
++        return LocalizedString("Please note that this value is outside of the recommended range.", comment: "Descriptive text for saving settings outside the recommended range for basal lock")
++    }
++}
+diff --git a/LoopKit/LoopKitUI/ViewModels/PreferencesViewModel.swift b/LoopKit/LoopKitUI/ViewModels/PreferencesViewModel.swift
+new file mode 100644
+index 00000000..785a23f1
+--- /dev/null
++++ b/LoopKit/LoopKitUI/ViewModels/PreferencesViewModel.swift
+@@ -0,0 +1,34 @@
++//
++//  PreferencesViewModel.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import LoopKit
++import HealthKit
++
++public class PreferencesViewModel: ObservableObject {
++    @Published var basalLockThreshold: HKQuantity
++    @Published var isBasalLockEnabled: Bool
++    
++    private var preferencesProvider: PreferencesProvider
++    
++    public init(preferencesProvider: PreferencesProvider) {
++        self.preferencesProvider = preferencesProvider
++        self.basalLockThreshold = preferencesProvider.basalLockThreshold
++        self.isBasalLockEnabled = preferencesProvider.isBasalLockEnabled
++    }
++    
++    func updateBasalLockThreshold(_ newValue: HKQuantity) {
++        preferencesProvider.basalLockThreshold = newValue
++        self.basalLockThreshold = newValue
++    }
++    
++    func updateBasalLockEnabled(_ newValue: Bool) {
++        preferencesProvider.isBasalLockEnabled = newValue
++        self.isBasalLockEnabled = newValue
++    }
++}
+diff --git a/LoopKit/LoopKitUI/Views/GuardrailConstrainedTimeIntervalView.swift b/LoopKit/LoopKitUI/Views/GuardrailConstrainedTimeIntervalView.swift
+new file mode 100644
+index 00000000..c473fd51
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/GuardrailConstrainedTimeIntervalView.swift
+@@ -0,0 +1,122 @@
++//
++//  GuardrailConstrainedTimeIntervalView.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import SwiftUI
++import HealthKit
++import LoopKit
++
++
++public struct GuardrailConstrainedTimeIntervalView: View {
++    @Environment(\.guidanceColors) var guidanceColors
++    var value: TimeInterval?
++    var guardrail: Guardrail<TimeInterval>
++    var isEditing: Bool
++    var isSupportedValue: Bool
++    var formatter: DateComponentsFormatter
++    var iconSpacing: CGFloat
++    var isUnitLabelVisible: Bool
++    var forceDisableAnimations: Bool
++    
++    @State private var hasAppeared = false
++    
++    public init(
++        value: TimeInterval,
++        guardrail: Guardrail<TimeInterval>,
++        isEditing: Bool,
++        isSupportedValue: Bool = true,
++        iconSpacing: CGFloat = 8,
++        isUnitLabelVisible: Bool = true,
++        forceDisableAnimations: Bool = false
++    ) {
++        self.value = value
++        self.guardrail = guardrail
++        self.isEditing = isEditing
++        self.isSupportedValue = isSupportedValue
++        self.iconSpacing = iconSpacing
++        self.isUnitLabelVisible = isUnitLabelVisible
++        self.forceDisableAnimations = forceDisableAnimations
++        
++        
++        self.formatter = {
++            let formatter = DateComponentsFormatter()
++            formatter.allowedUnits = [.hour, .minute]
++            formatter.unitsStyle = .short
++            formatter.zeroFormattingBehavior = [.dropLeading, .dropTrailing]
++            
++            return formatter
++        }()
++    }
++    
++    public var body: some View {
++        HStack {
++            HStack(spacing: iconSpacing) {
++                if value != nil {
++                    if guardrail.classification(for: value!) != .withinRecommendedRange {
++                        Image(systemName: "exclamationmark.triangle.fill")
++                            .foregroundColor(warningColor)
++                            .transition(.springInDisappear)
++                    }
++                    
++                    Text(formatter.string(from: value!) ?? "")
++                        .foregroundColor(warningColor)
++                        .fixedSize(horizontal: true, vertical: false)
++                } else {
++                    Text("–")
++                        .foregroundColor(.secondary)
++                }
++            }
++            
++/*            if isUnitLabelVisible {
++                Text(unit.shortLocalizedUnitString())
++                    .foregroundColor(Color(.secondaryLabel))
++            }*/
++        }
++        .accessibilityElement(children: .combine)
++        .onAppear { self.hasAppeared = true }
++        .animation(animation)
++    }
++    
++    private var animation: Animation? {
++        // A conditional implicit animation seems to behave funky on first appearance.
++        // Disable animations until the view has appeared.
++        if forceDisableAnimations || !hasAppeared {
++            return nil
++        }
++        
++        // While editing, the text width is liable to change, which can cause a slow-feeling animation
++        // of the guardrail warning icon. Disable animations while editing.
++        return isEditing ? nil : .default
++    }
++    
++    private var warningColor: Color {
++        guard let value = value else {
++            return .primary
++        }
++        
++        guard isSupportedValue else { return guidanceColors.critical }
++        
++        switch guardrail.classification(for: value) {
++        case .withinRecommendedRange:
++            return isEditing ? .accentColor : guidanceColors.acceptable
++        case .outsideRecommendedRange(let threshold):
++            switch threshold {
++            case .minimum, .maximum:
++                return guidanceColors.critical
++            case .belowRecommended, .aboveRecommended:
++                return guidanceColors.warning
++            }
++        }
++    }
++}
++
++fileprivate extension AnyTransition {
++    static let springInDisappear = asymmetric(
++        insertion: AnyTransition.scale.animation(.spring(dampingFraction: 0.5)),
++        removal: .identity
++    )
++}
+diff --git a/LoopKit/LoopKitUI/Views/Preferences Editors/BasalLockEditor.swift b/LoopKit/LoopKitUI/Views/Preferences Editors/BasalLockEditor.swift
+new file mode 100644
+index 00000000..dc313a9c
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/Preferences Editors/BasalLockEditor.swift	
+@@ -0,0 +1,209 @@
++//
++//  BasalLockEditor.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import SwiftUI
++import HealthKit
++import LoopKit
++
++public struct BasalLockEditor: View {
++    @EnvironmentObject private var displayGlucosePreference: DisplayGlucosePreference
++    
++    @Environment(\.dismissAction) var dismiss
++    @Environment(\.authenticate) var authenticate
++    @Environment(\.appName) private var appName
++    
++    let viewModel: PreferencesViewModel
++    let didSave: (() -> Void)?
++    
++    @State private var userDidTap: Bool = false
++    @State private var isBasalLockEnabled: Bool
++    @State private var threshold: HKQuantity
++    @State private var isEditing = false
++    @State private var showingConfirmationAlert = false
++    
++    private var initialValue: HKQuantity {
++        viewModel.basalLockThreshold
++    }
++    
++    public init(preferencesViewModel: PreferencesViewModel, didSave: (() -> Void)? = nil) {
++        self.viewModel = preferencesViewModel
++        self._isBasalLockEnabled = State(initialValue: preferencesViewModel.isBasalLockEnabled)
++        self._threshold = State(initialValue: preferencesViewModel.basalLockThreshold)
++        self.didSave = didSave
++    }
++    
++    public var body: some View {
++        contentWithCancel
++            .navigationBarTitle("", displayMode: .inline)
++    }
++    
++    private var contentWithCancel: some View {
++        content
++            .navigationBarBackButtonHidden(isBasalLockEnabled != viewModel.isBasalLockEnabled || threshold != viewModel.basalLockThreshold)
++            .toolbar {
++                ToolbarItem(placement: .navigationBarLeading) {
++                    leadingNavigationBarItem
++                }
++            }
++    }
++    
++    @ViewBuilder
++    private var leadingNavigationBarItem: some View {
++        if isBasalLockEnabled != viewModel.isBasalLockEnabled || threshold != viewModel.basalLockThreshold {
++            cancelButton
++        } else {
++            EmptyView()
++        }
++    }
++    
++    private var cancelButton: some View {
++        Button(action: { self.dismiss() }) {
++            Text(LocalizedString("Cancel", comment: "Cancel editing settings button title"))
++        }
++    }
++    
++    private var picker: GlucoseValuePicker {
++        GlucoseValuePicker(
++            value: self.$threshold.animation(),
++            unit: displayGlucosePreference.unit,
++            guardrail: .basalLockThreshold,
++            bounds: Guardrail.basalLockThreshold.absoluteBounds.lowerBound...Guardrail.basalLockThreshold.absoluteBounds.upperBound
++        )
++    }
++    
++    private var content: some View {
++        ConfigurationPage(
++            title: Text(LocalizedString("Basal Lock Threshold", comment: "Title for basal lock threshold setting")),
++            actionButtonTitle: Text(LocalizedString("Save", comment: "Save button title")),
++            actionButtonState: saveButtonState,
++            cards: {
++                Card {
++                    description
++                        .font(.callout)
++                        .foregroundColor(Color(.secondaryLabel))
++                        .fixedSize(horizontal: false, vertical: true)
++                    
++                    Toggle(isOn: $isBasalLockEnabled) {
++                        Text("Enable Basal Lock")
++                    }
++                    .animation(.default, value: isBasalLockEnabled)
++                    
++                    ExpandableSetting(
++                        isEditing: $isEditing,
++                        valueContent: {
++                            GuardrailConstrainedQuantityView(
++                                value: threshold,
++                                unit: displayGlucosePreference.unit,
++                                guardrail: .basalLockThreshold,
++                                isEditing: isEditing,
++                                // Workaround for strange animation behavior on appearance
++                                forceDisableAnimations: true
++                            )
++                        },
++                        expandedContent: {
++                            // Prevent the picker from expanding the card's width on small devices
++                            picker.frame(maxWidth: 200)
++                        }
++                    )
++                    .transition(.slide)
++                }
++            },
++            actionAreaContent: {
++                instructionalContentIfNecessary
++                if isBasalLockEnabled && warningThreshold != nil && userDidTap {
++                    PreferencesGuardrailWarning(preferencesSetting: .basalLock, title: basalLockTitle, threshold: warningThreshold!)
++                        .transition(.slide)
++                }
++            },
++            action: {
++                if self.warningThreshold == nil {
++                    self.startSaving()
++                } else {
++                    self.showingConfirmationAlert = true
++                }
++            }
++        )
++        .alert(isPresented: $showingConfirmationAlert, content: confirmationAlert)
++        .simultaneousGesture(TapGesture().onEnded {
++            withAnimation {
++                self.userDidTap = true
++            }
++        })
++    }
++    
++    private var basalLockTitle: Text {
++        Text(LocalizedString("Basal Lock Threshold", comment: "Title for basal lock threshold setting"))
++    }
++    
++    private var description: Text {
++        Text(LocalizedString("Basal Lock prevents the basal rate from being throttled if the blood glucose is above a certain level.", comment: "Description for basal lock threshold setting"))
++    }
++    
++    private var instructionalContentIfNecessary: some View {
++        Group {
++            if !userDidTap {
++                instructionalContent
++            }
++        }
++    }
++    
++    private var instructionalContent: some View {
++        HStack {
++            Text(LocalizedString("You can edit the setting by tapping into the line item.", comment: "Description of how to edit setting"))
++                .foregroundColor(.secondary)
++                .font(.subheadline)
++            Spacer()
++        }
++    }
++    
++    private var saveButtonState: ConfigurationPageActionButtonState {
++        let selectableValues = picker.selectableValues
++        let adjustedBounds = (selectableValues.first!)...(selectableValues.last!)
++        guard adjustedBounds.contains(threshold.doubleValue(for: displayGlucosePreference.unit)) else {
++            return .disabled
++        }
++        return (isBasalLockEnabled != viewModel.isBasalLockEnabled || threshold != viewModel.basalLockThreshold) ? .enabled : .disabled
++    }
++    
++    private var warningThreshold: SafetyClassification.Threshold? {
++        switch Guardrail.basalLockThreshold.classification(for: threshold) {
++        case .withinRecommendedRange:
++            return nil
++        case .outsideRecommendedRange(let threshold):
++            return threshold
++        }
++    }
++    
++    private func confirmationAlert() -> SwiftUI.Alert {
++        SwiftUI.Alert(
++            title: Text(LocalizedString("Save Basal Lock Threshold?", comment: "Alert title for confirming a basal lock threshold outside the recommended range")),
++            message: Text(LocalizedString("Your setting for basal lock is outside the recommended range.", comment: "Descriptive text for saving settings outside the recommended range for basal lock")),
++            primaryButton: .cancel(Text(LocalizedString("Go Back", comment: "Text for go back action on confirmation alert"))),
++            secondaryButton: .default(
++                Text(LocalizedString("Continue", comment: "Text for continue action on confirmation alert")),
++                action: startSaving
++            )
++        )
++    }
++    
++    private func startSaving() {
++        authenticate(LocalizedString("Authentication is required to save this setting.", comment: "Authentication challenge description for basal lock threshold")) {
++            switch $0 {
++            case .success: self.continueSaving()
++            case .failure: break
++            }
++        }
++    }
++    
++    private func continueSaving() {
++        viewModel.updateBasalLockEnabled(self.isBasalLockEnabled)
++        viewModel.updateBasalLockThreshold(self.threshold)
++        didSave?()
++        self.dismiss()
++    }
++}
+diff --git a/LoopKit/LoopKitUI/Views/Preferences Editors/PreferencesGuardrailWarning.swift b/LoopKit/LoopKitUI/Views/Preferences Editors/PreferencesGuardrailWarning.swift
+new file mode 100644
+index 00000000..3a7dd0ad
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/Preferences Editors/PreferencesGuardrailWarning.swift	
+@@ -0,0 +1,101 @@
++//
++//  PreferencesGuardrailWarning.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import SwiftUI
++import LoopKit
++
++public struct PreferencesGuardrailWarning: View {
++    private enum CrossedThresholds {
++        case one(SafetyClassification.Threshold)
++        case oneOrMore([SafetyClassification.Threshold])
++    }
++    
++    private var title: Text
++    private var crossedThresholds: CrossedThresholds
++    private var captionOverride: Text?
++    private var preferencesSetting: PreferencesSetting
++    
++    public init(
++        preferencesSetting: PreferencesSetting,
++        title: Text,
++        threshold: SafetyClassification.Threshold,
++        caption: Text? = nil
++    ) {
++        self.preferencesSetting = preferencesSetting
++        self.title = title
++        self.crossedThresholds = .one(threshold)
++        self.captionOverride = caption
++    }
++    
++    public init(
++        preferencesSetting: PreferencesSetting,
++        title: Text,
++        thresholds: [SafetyClassification.Threshold],
++        caption: Text? = nil
++    ) {
++        precondition(!thresholds.isEmpty)
++        self.preferencesSetting = preferencesSetting
++        self.title = title
++        self.crossedThresholds = .oneOrMore(thresholds)
++        self.captionOverride = caption
++    }
++    
++    public var body: some View {
++        WarningView(title: title, caption: caption, severity: severity)
++    }
++    
++    private var severity: WarningSeverity {
++        switch crossedThresholds {
++        case .one(let threshold):
++            return threshold.severity
++        case .oneOrMore(let thresholds):
++            return thresholds.lazy.map({ $0.severity }).max()!
++        }
++    }
++    
++    private var caption: Text {
++        if let caption = captionOverride {
++            return caption
++        }
++        
++        switch crossedThresholds {
++        case .one(let threshold):
++            return captionForThreshold(threshold)
++        case .oneOrMore(let thresholds):
++            if thresholds.count == 1, let threshold = thresholds.first {
++                return captionForThreshold(threshold)
++            } else {
++                return captionForThresholds()
++            }
++        }
++    }
++    
++    private func captionForThreshold(_ threshold: SafetyClassification.Threshold) -> Text {
++        switch threshold {
++        case .minimum, .belowRecommended:
++            return Text(preferencesSetting.guardrailCaptionForLowValue)
++        case .aboveRecommended, .maximum:
++            return Text(preferencesSetting.guardrailCaptionForHighValue)
++        }
++    }
++    
++    private func captionForThresholds() -> Text {
++        return Text(preferencesSetting.guardrailCaptionForOutsideValues)
++    }
++}
++
++fileprivate extension SafetyClassification.Threshold {
++    var severity: WarningSeverity {
++        switch self {
++        case .belowRecommended, .aboveRecommended:
++            return .default
++        case .minimum, .maximum:
++            return .critical
++        }
++    }
++}
+diff --git a/LoopKit/LoopKitUI/Views/Preferences Editors/PreferencesView.swift b/LoopKit/LoopKitUI/Views/Preferences Editors/PreferencesView.swift
+new file mode 100644
+index 00000000..41476c35
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/Preferences Editors/PreferencesView.swift	
+@@ -0,0 +1,141 @@
++//
++//  PreferencesView.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2024-02-25.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import SwiftUI
++import LoopKit
++import HealthKit
++
++public struct PreferencesView: View {
++    @Environment(\.dismissAction) private var dismiss
++    @Environment(\.appName) private var appName
++    @EnvironmentObject var displayGlucosePreference: DisplayGlucosePreference
++    
++    @ObservedObject var viewModel: PreferencesViewModel
++    
++    public init(viewModel: PreferencesViewModel) {
++        self.viewModel = viewModel
++    }
++    
++    private static func createFormatter(for unit: HKUnit) -> NumberFormatter {
++        let quantityFormatter = QuantityFormatter(for: unit)
++        return quantityFormatter.numberFormatter
++    }
++    
++    public var body: some View {
++        navigationViewWrappedContent
++    }
++    
++    private var formatter: NumberFormatter {
++        let quantityFormatter = QuantityFormatter(for: displayGlucosePreference.unit)
++        return quantityFormatter.numberFormatter
++    }
++}
++
++extension PreferencesView {
++    private var navigationViewWrappedContent: some View {
++        NavigationView {
++            ZStack {
++                Color(.systemGroupedBackground)
++                    .edgesIgnoringSafeArea(.all)
++                content
++                    .toolbar {
++                        ToolbarItem(placement: .navigationBarTrailing) {
++                            dismissButton
++                        }
++                    }
++                    .navigationBarTitle(preferencesTitle, displayMode: .large)
++            }
++        }
++    }
++    
++    private var dismissButton: some View {
++        Button(action: dismiss) {
++            Text("Done")
++        }
++    }
++    
++    private var preferencesTitle: String {
++        return "Preferences"
++    }
++    
++    private var content: some View {
++        CardList(title: nil, style: .sectioned(cardListSections)) //, trailer: cardListTrailer
++    }
++    
++    private var cardListSections: [CardListSection] {
++        var cardListSections: [CardListSection] = []
++        
++        cardListSections.append(preferencesCardListSection)
++        
++        return cardListSections
++    }
++    
++    private var preferencesCardListSection: CardListSection {
++        CardListSection {
++            preferencesCardStack
++                .spacing(20)
++        }
++    }
++    
++    private var preferencesCardStack: CardStack {
++        var cards: [Card] = []
++        
++        cards.append(basalLockSection)
++        
++        return CardStack(cards: cards)
++    }
++    
++    @ViewBuilder
++    func screen(for setting: PreferencesSetting, dismiss: @escaping () -> Void) -> some View {
++        switch setting {
++        case .basalLock:
++            BasalLockEditor(preferencesViewModel: viewModel, didSave: dismiss)
++        }
++    }
++    
++    private func card<Content>(for preferencesSetting: PreferencesSetting, @ViewBuilder content: @escaping () -> Content) -> Card where Content: View {
++        Card {
++            SectionWithTapToEdit(
++                isEnabled: true,
++                title: preferencesSetting.title,
++                descriptiveText: preferencesSetting.descriptiveText(appName: appName),
++                destination: { dismiss in
++                    screen(for: preferencesSetting, dismiss: dismiss)
++                        .environment(\.dismissAction, dismiss)
++                },
++                content: content
++            )
++        }
++    }
++    
++    private var basalLockSection: Card {
++        card(for: .basalLock) {
++            SectionDivider()
++            HStack {
++                Spacer()
++                if viewModel.isBasalLockEnabled {
++                    HStack(alignment: .firstTextBaseline) {
++                        Text(formatter.string(for: viewModel.basalLockThreshold.doubleValue(for: displayGlucosePreference.unit)) ?? "")
++                        Text(displayGlucosePreference.unit.shortLocalizedUnitString())
++                            .foregroundColor(Color(.secondaryLabel))
++                    }
++                } else {
++                    Text("Off")
++                        .foregroundColor(Color(.secondaryLabel))
++                }
++            }
++        }
++    }
++}
++
++fileprivate struct SectionDivider: View {
++    var body: some View {
++        Divider()
++            .padding(.trailing, -16)
++    }
++}

--- a/live_activity/dev377_live_activity.patch
+++ b/live_activity/dev377_live_activity.patch
@@ -1,0 +1,2400 @@
+Submodule Loop 20c313c..e80e515:
+diff --git a/Loop/Loop Widget Extension/Bootstrap/Bootstrap.swift b/Loop/Loop Widget Extension/Bootstrap/Bootstrap.swift
+new file mode 100644
+index 00000000..00823471
+--- /dev/null
++++ b/Loop/Loop Widget Extension/Bootstrap/Bootstrap.swift	
+@@ -0,0 +1,11 @@
++//
++//  Bootstrap.swift
++//  Loop Widget Extension
++//
++//  Created by Bastiaan Verhaar on 25/06/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++
++class Bootstrap{}
+diff --git a/Loop/Loop Widget Extension/Helpers/LocalizedString.swift b/Loop/Loop Widget Extension/Helpers/LocalizedString.swift
+new file mode 100644
+index 00000000..15818175
+--- /dev/null
++++ b/Loop/Loop Widget Extension/Helpers/LocalizedString.swift	
+@@ -0,0 +1,21 @@
++//
++//  LocalizedString.swift
++//  Loop Widget Extension
++//
++//  Created by Bastiaan Verhaar on 25/06/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++
++private class FrameworkBundle {
++    static let main = Bundle(for: Bootstrap.self)
++}
++
++func LocalizedString(_ key: String, tableName: String? = nil, value: String? = nil, comment: String) -> String {
++    if let value = value {
++        return NSLocalizedString(key, tableName: tableName, bundle: FrameworkBundle.main, value: value, comment: comment)
++    } else {
++        return NSLocalizedString(key, tableName: tableName, bundle: FrameworkBundle.main, comment: comment)
++    }
++}
+diff --git a/Loop/Loop Widget Extension/Live Activity/BasalViewActivity.swift b/Loop/Loop Widget Extension/Live Activity/BasalViewActivity.swift
+new file mode 100644
+index 00000000..915335c5
+--- /dev/null
++++ b/Loop/Loop Widget Extension/Live Activity/BasalViewActivity.swift	
+@@ -0,0 +1,46 @@
++//
++//  BasalView.swift
++//  Loop
++//
++//  Created by Noah Brauner on 8/15/22.
++//  Copyright © 2022 LoopKit Authors. All rights reserved.
++//
++
++import SwiftUI
++
++struct BasalViewActivity: View {
++    let percent: Double
++    let rate: Double
++    
++    var body: some View {        
++        VStack(spacing: 1) {
++            BasalRateView(percent: percent)
++                .overlay(
++                    BasalRateView(percent: percent)
++                        .stroke(Color("insulin"), lineWidth: 2)
++                )
++                .foregroundColor(Color("insulin").opacity(0.5))
++                .frame(width: 44, height: 22)
++
++            if let rateString = decimalFormatter.string(from: NSNumber(value: rate)) {
++                Text("\(rateString)U")
++                    .font(.subheadline)
++            }
++            else {
++                Text("-U")
++                    .font(.subheadline)
++            }
++        }
++    }
++    
++    private let decimalFormatter: NumberFormatter = {
++        let formatter = NumberFormatter()
++        formatter.numberStyle = .decimal
++        formatter.minimumFractionDigits = 1
++        formatter.minimumIntegerDigits = 1
++        formatter.positiveFormat = "+0.0##"
++        formatter.negativeFormat = "-0.0##"
++
++        return formatter
++    }()
++}
+diff --git a/Loop/Loop Widget Extension/Live Activity/ChartView.swift b/Loop/Loop Widget Extension/Live Activity/ChartView.swift
+new file mode 100644
+index 00000000..b65e02c9
+--- /dev/null
++++ b/Loop/Loop Widget Extension/Live Activity/ChartView.swift	
+@@ -0,0 +1,159 @@
++//
++//  ChartValues.swift
++//  Loop Widget Extension
++//
++//  Created by Bastiaan Verhaar on 25/06/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import SwiftUI
++import Charts
++
++struct ChartView: View {
++    private let glucoseSampleData: [ChartValues]
++    private let predicatedData: [ChartValues]
++    private let glucoseRanges: [GlucoseRangeValue]
++    private let preset: Preset?
++    private let yAxisMarks: [Double]
++    
++    init(glucoseSamples: [GlucoseSampleAttributes], predicatedGlucose: [Double], predicatedStartDate: Date?, predicatedInterval: TimeInterval?, useLimits: Bool, lowerLimit: Double, upperLimit: Double, glucoseRanges: [GlucoseRangeValue], preset: Preset?, yAxisMarks: [Double]) {
++        self.glucoseSampleData = ChartValues.convert(data: glucoseSamples, useLimits: useLimits, lowerLimit: lowerLimit, upperLimit: upperLimit)
++        self.predicatedData = ChartValues.convert(
++            data: predicatedGlucose,
++            startDate: predicatedStartDate ?? Date.now,
++            interval: predicatedInterval ?? .minutes(5),
++            useLimits: useLimits,
++            lowerLimit: lowerLimit,
++            upperLimit: upperLimit
++        )
++        self.preset = preset
++        self.glucoseRanges = glucoseRanges
++        self.yAxisMarks = yAxisMarks
++    }
++    
++    init(glucoseSamples: [GlucoseSampleAttributes], useLimits: Bool, lowerLimit: Double, upperLimit: Double, glucoseRanges: [GlucoseRangeValue], preset: Preset?, yAxisMarks: [Double]) {
++        self.glucoseSampleData = ChartValues.convert(data: glucoseSamples, useLimits: useLimits, lowerLimit: lowerLimit, upperLimit: upperLimit)
++        self.predicatedData = []
++        self.preset = preset
++        self.glucoseRanges = glucoseRanges
++        self.yAxisMarks = yAxisMarks
++    }
++    
++    var body: some View {
++        ZStack(alignment: Alignment(horizontal: .trailing, vertical: .top)){
++            Chart {
++                if let preset = self.preset, predicatedData.count > 0, preset.endDate > Date.now.addingTimeInterval(.hours(-6)) {
++                    RectangleMark(
++                        xStart: .value("Start", preset.startDate),
++                        xEnd: .value("End", preset.endDate),
++                        yStart: .value("Preset override", preset.minValue),
++                        yEnd: .value("Preset override", preset.maxValue)
++                    )
++                    .foregroundStyle(.primary)
++                    .opacity(0.6)
++                }
++                
++                ForEach(glucoseRanges) { item in
++                    RectangleMark(
++                        xStart: .value("Start", item.startDate),
++                        xEnd: .value("End", item.endDate),
++                        yStart: .value("Glucose range", item.minValue),
++                        yEnd: .value("Glucose range", item.maxValue)
++                    )
++                    .foregroundStyle(.primary)
++                    .opacity(0.3)
++                }
++                
++                ForEach(glucoseSampleData) { item in
++                    PointMark (x: .value("Date", item.x),
++                               y: .value("Glucose level", item.y)
++                    )
++                    .symbolSize(20)
++                    .foregroundStyle(by: .value("Color", item.color))
++                }
++                
++                ForEach(predicatedData) { item in
++                    LineMark (x: .value("Date", item.x),
++                              y: .value("Glucose level", item.y)
++                    )
++                    .lineStyle(StrokeStyle(lineWidth: 3, dash: [2, 3]))
++                }
++            }
++            .chartForegroundStyleScale([
++                "Good": .green,
++                "High": .orange,
++                "Low": .red,
++                "Default": .blue
++            ])
++            .chartPlotStyle { plotContent in
++                plotContent.background(.cyan.opacity(0.15))
++            }
++            .chartLegend(.hidden)
++            .chartYScale(domain: [yAxisMarks.first ?? 0, yAxisMarks.last ?? 0])
++            .chartYAxis {
++                AxisMarks(values: yAxisMarks)
++            }
++            .chartYAxis {
++                AxisMarks(position: .leading) { _ in
++                    AxisValueLabel().foregroundStyle(Color.primary)
++                    AxisGridLine(stroke: .init(lineWidth: 0.1, dash: [2, 3]))
++                        .foregroundStyle(Color.primary)
++                }
++            }
++            .chartXAxis {
++                AxisMarks(position: .automatic, values: .stride(by: .hour)) { _ in
++                    AxisValueLabel(format: .dateTime.hour(.twoDigits(amPM: .narrow)), anchor: .top)
++                        .foregroundStyle(Color.primary)
++                    AxisGridLine(stroke: .init(lineWidth: 0.1, dash: [2, 3]))
++                        .foregroundStyle(Color.primary)
++                }
++            }
++            
++            if let preset = self.preset, preset.endDate > Date.now {
++                Text(preset.title)
++                    .font(.footnote)
++                    .padding(.trailing, 5)
++                    .padding(.top, 2)
++            }
++        }
++    }
++}
++
++struct ChartValues: Identifiable {
++    public let id: UUID
++    public let x: Date
++    public let y: Double
++    public let color: String
++    
++    init(x: Date, y: Double, color: String) {
++        self.id = UUID()
++        self.x = x
++        self.y = y
++        self.color = color
++    }
++    
++    static func convert(data: [Double], startDate: Date, interval: TimeInterval, useLimits: Bool, lowerLimit: Double, upperLimit: Double) -> [ChartValues] {
++        let twoHours = Date.now.addingTimeInterval(.hours(4))
++        
++        return data.enumerated().filter { (index, item) in
++            return startDate.addingTimeInterval(interval * Double(index)) < twoHours
++        }.map { (index, item) in
++            return ChartValues(
++                x: startDate.addingTimeInterval(interval * Double(index)),
++                y: item,
++                color: !useLimits ? "Default" : item < lowerLimit ? "Low" : item > upperLimit ? "High" : "Good"
++            )
++        }
++    }
++    
++    static func convert(data: [GlucoseSampleAttributes], useLimits: Bool, lowerLimit: Double, upperLimit: Double) -> [ChartValues] {
++        return data.map { item in
++            return ChartValues(
++                x: item.x,
++                y: item.y,
++                color: !useLimits ? "Default" : item.y < lowerLimit ? "Low" : item.y > upperLimit ? "High" : "Good"
++            )
++        }
++    }
++}
+diff --git a/Loop/Loop Widget Extension/Live Activity/GlucoseLiveActivityConfiguration.swift b/Loop/Loop Widget Extension/Live Activity/GlucoseLiveActivityConfiguration.swift
+new file mode 100644
+index 00000000..4d5ed5ef
+--- /dev/null
++++ b/Loop/Loop Widget Extension/Live Activity/GlucoseLiveActivityConfiguration.swift	
+@@ -0,0 +1,298 @@
++//
++//  LiveActivityConfiguration.swift
++//  Loop Widget Extension
++//
++//  Created by Bastiaan Verhaar on 23/06/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import ActivityKit
++import LoopKit
++import SwiftUI
++import LoopCore
++import WidgetKit
++import Charts
++import HealthKit
++
++@available(iOS 16.2, *)
++struct GlucoseLiveActivityConfiguration: Widget {
++    private let timeFormatter: DateFormatter = {
++        let dateFormatter = DateFormatter()
++        dateFormatter.dateStyle = .none
++        dateFormatter.timeStyle = .short
++        
++        return dateFormatter
++    }()
++    
++    var body: some WidgetConfiguration {
++        ActivityConfiguration(for: GlucoseActivityAttributes.self) { context in
++            // Create the presentation that appears on the Lock Screen and as a
++            // banner on the Home Screen of devices that don't support the Dynamic Island.
++            ZStack {
++                VStack {
++                    if context.attributes.mode == .large {
++                        HStack(spacing: 15) {
++                            loopIcon(context)
++                            if context.attributes.addPredictiveLine {
++                                ChartView(
++                                    glucoseSamples: context.state.glucoseSamples,
++                                    predicatedGlucose: context.state.predicatedGlucose,
++                                    predicatedStartDate: context.state.predicatedStartDate,
++                                    predicatedInterval: context.state.predicatedInterval,
++                                    useLimits: context.attributes.useLimits,
++                                    lowerLimit: context.state.isMmol ? context.attributes.lowerLimitChartMmol : context.attributes.lowerLimitChartMg,
++                                    upperLimit: context.state.isMmol ? context.attributes.upperLimitChartMmol : context.attributes.upperLimitChartMg,
++                                    glucoseRanges: context.state.glucoseRanges,
++                                    preset: context.state.preset,
++                                    yAxisMarks: context.state.yAxisMarks
++                                )
++                                .frame(height: 85)
++                            } else {
++                                ChartView(
++                                    glucoseSamples: context.state.glucoseSamples,
++                                    useLimits: context.attributes.useLimits,
++                                    lowerLimit: context.state.isMmol ? context.attributes.lowerLimitChartMmol : context.attributes.lowerLimitChartMg,
++                                    upperLimit: context.state.isMmol ? context.attributes.upperLimitChartMmol : context.attributes.upperLimitChartMg,
++                                    glucoseRanges: context.state.glucoseRanges,
++                                    preset: context.state.preset,
++                                    yAxisMarks: context.state.yAxisMarks
++                                )
++                                .frame(height: 85)
++                            }
++                        }
++                    }
++                    
++                    HStack {
++                        bottomSpacer(border: false)
++                        
++                        let endIndex = context.state.bottomRow.endIndex - 1
++                        ForEach(Array(context.state.bottomRow.enumerated()), id: \.element) { (index, item) in
++                            switch (item.type) {
++                            case .generic:
++                                bottomItemGeneric(
++                                    title: item.label,
++                                    value: item.value,
++                                    unit: LocalizedString(item.unit, comment: "No comment")
++                                )
++                                
++                            case .basal:
++                                BasalViewActivity(percent: item.percentage, rate: item.rate)
++                                
++                            case .currentBg:
++                                bottomItemCurrentBG(
++                                    value: item.value,
++                                    trend: item.trend,
++                                    context: context
++                                )
++                                
++                            case .loopCircle:
++                                bottomItemLoopCircle(context: context)
++                            }
++                            
++                            if index != endIndex {
++                                bottomSpacer(border: true)
++                            }
++                        }
++                        
++                        bottomSpacer(border: false)
++                    }
++                }
++                if context.state.ended {
++                    VStack {
++                        Spacer()
++                        HStack {
++                            Spacer()
++                            Text(NSLocalizedString("Open the app to update the widget", comment: "No comment"))
++                            Spacer()
++                        }
++                        Spacer()
++                    }
++                    .background(.ultraThinMaterial.opacity(0.8))
++                    .padding(.all, -15)
++                }
++            }
++                .privacySensitive()
++                .padding(.all, 15)
++                .background(BackgroundStyle.background.opacity(0.4))
++                .activityBackgroundTint(Color.clear)
++        } dynamicIsland: { context in
++            let glucoseFormatter = NumberFormatter.glucoseFormatter(for: context.state.isMmol ? HKUnit.millimolesPerLiter : HKUnit.milligramsPerDeciliter)
++            
++            return DynamicIsland {
++                DynamicIslandExpandedRegion(.leading) {
++                    HStack(alignment: .center) {
++                        loopIcon(context)
++                            .frame(width: 40, height: 40, alignment: .trailing)
++                        Spacer()
++                        Text("\(glucoseFormatter.string(from: context.state.currentGlucose) ?? "??")\(getArrowImage(context.state.trendType))")
++                            .foregroundStyle(getGlucoseColor(context.state.currentGlucose, context: context))
++                            .font(.headline)
++                            .fontWeight(.heavy)
++                    }
++                }
++                DynamicIslandExpandedRegion(.trailing) {
++                    HStack{
++                        Text(context.state.delta)
++                            .foregroundStyle(Color(white: 0.9))
++                            .font(.headline)
++                        Text(context.state.isMmol ? HKUnit.millimolesPerLiter.localizedShortUnitString : HKUnit.milligramsPerDeciliter.localizedShortUnitString)
++                            .foregroundStyle(Color(white: 0.7))
++                            .font(.subheadline)
++                    }
++                }
++                DynamicIslandExpandedRegion(.bottom) {
++                    if context.attributes.addPredictiveLine {
++                        ChartView(
++                            glucoseSamples: context.state.glucoseSamples,
++                            predicatedGlucose: context.state.predicatedGlucose,
++                            predicatedStartDate: context.state.predicatedStartDate,
++                            predicatedInterval: context.state.predicatedInterval,
++                            useLimits: context.attributes.useLimits,
++                            lowerLimit: context.state.isMmol ? context.attributes.lowerLimitChartMmol : context.attributes.lowerLimitChartMg,
++                            upperLimit: context.state.isMmol ? context.attributes.upperLimitChartMmol : context.attributes.upperLimitChartMg,
++                            glucoseRanges: context.state.glucoseRanges,
++                            preset: context.state.preset,
++                            yAxisMarks: context.state.yAxisMarks
++                        )
++                            .frame(height: 75)
++                    } else {
++                        ChartView(
++                            glucoseSamples: context.state.glucoseSamples,
++                            useLimits: context.attributes.useLimits,
++                            lowerLimit: context.state.isMmol ? context.attributes.lowerLimitChartMmol : context.attributes.lowerLimitChartMg,
++                            upperLimit: context.state.isMmol ? context.attributes.upperLimitChartMmol : context.attributes.upperLimitChartMg,
++                            glucoseRanges: context.state.glucoseRanges,
++                            preset: context.state.preset,
++                            yAxisMarks: context.state.yAxisMarks
++                        )
++                            .frame(height: 75)
++                    }
++                }
++            } compactLeading: {
++                Text("\(glucoseFormatter.string(from: context.state.currentGlucose) ?? "??")\(getArrowImage(context.state.trendType))")
++                    .foregroundStyle(getGlucoseColor(context.state.currentGlucose, context: context))
++                    .minimumScaleFactor(0.1)
++            } compactTrailing: {
++                Text(context.state.delta)
++                    .foregroundStyle(Color(white: 0.9))
++                    .minimumScaleFactor(0.1)
++            } minimal: {
++                Text(glucoseFormatter.string(from: context.state.currentGlucose) ?? "??")
++                    .foregroundStyle(getGlucoseColor(context.state.currentGlucose, context: context))
++                    .minimumScaleFactor(0.1)
++            }
++        }
++    }
++    
++    @ViewBuilder
++    private func loopIcon(_ context: ActivityViewContext<GlucoseActivityAttributes>) -> some View {
++        Circle()
++            .trim(from: context.state.isCloseLoop ? 0 : 0.2, to: 1)
++            .stroke(getLoopColor(context.state.lastCompleted), lineWidth: 8)
++            .rotationEffect(Angle(degrees: -126))
++            .frame(width: 36, height: 36)
++    }
++    
++    @ViewBuilder
++    private func bottomItemGeneric(title: String, value: String, unit: String) -> some View {
++        VStack(alignment: .center) {
++            Text("\(value)\(unit)")
++                .font(.headline)
++                .foregroundStyle(.primary)
++                .fontWeight(.heavy)
++                .font(Font.body.leading(.tight))
++            Text(title)
++                .font(.subheadline)
++        }
++    }
++    
++    @ViewBuilder
++    private func bottomItemCurrentBG(value: String, trend: GlucoseTrend?, context: ActivityViewContext<GlucoseActivityAttributes>) -> some View {
++        VStack(alignment: .center) {
++            HStack {
++                Text(value + getArrowImage(trend))
++                    .font(.title)
++                    .foregroundStyle(!context.attributes.useLimits ? .primary : getGlucoseColor(context.state.currentGlucose, context: context))
++                    .fontWeight(.heavy)
++                    .font(Font.body.leading(.tight))
++            }
++        }
++    }
++    
++    @ViewBuilder
++    private func bottomItemLoopCircle(context: ActivityViewContext<GlucoseActivityAttributes>) -> some View {
++        VStack(alignment: .center) {
++            loopIcon(context)
++        }
++    }
++    
++    @ViewBuilder
++    private func bottomSpacer(border: Bool) -> some View {
++        Spacer()
++        if (border) {
++            Divider()
++                .background(.secondary)
++            Spacer()
++        }
++        
++    }
++    
++    private func getArrowImage(_ trendType: GlucoseTrend?) -> String {
++        switch trendType {
++        case .upUpUp:
++            return "\u{2191}\u{2191}" // ↑↑
++        case .upUp:
++            return "\u{2191}" // ↑
++        case .up:
++            return "\u{2197}" // ↗
++        case .flat:
++            return "\u{2192}" // →
++        case .down:
++            return "\u{2198}" // ↘
++        case .downDown:
++            return "\u{2193}" // ↓
++        case .downDownDown:
++            return "\u{2193}\u{2193}" // ↓↓
++        case .none:
++            return ""
++        }
++    }
++    
++    private func getLoopColor(_ age: Date?) -> Color {
++        var freshness: LoopCompletionFreshness = .stale
++        if let age = age {
++            freshness = LoopCompletionFreshness(age: abs(min(0, age.timeIntervalSinceNow)))
++        }
++        
++        switch freshness {
++        case .fresh:
++            return Color("fresh")
++        case .aging:
++            return Color("warning")
++        case .stale:
++            return .red
++        }
++    }
++    
++    private func getGlucoseColor(_ value: Double, context: ActivityViewContext<GlucoseActivityAttributes>) -> Color {
++        guard context.attributes.useLimits else {
++            return .primary
++        }
++        
++        if
++            context.state.isMmol && value < context.attributes.lowerLimitChartMmol ||
++            !context.state.isMmol && value < context.attributes.lowerLimitChartMg
++        {
++            return .red
++        }
++        
++        if
++            context.state.isMmol && value > context.attributes.upperLimitChartMmol ||
++            !context.state.isMmol && value > context.attributes.upperLimitChartMg
++        {
++            return .orange
++        }
++        
++        return .green
++    }
++}
+diff --git a/Loop/Loop Widget Extension/LoopWidgets.swift b/Loop/Loop Widget Extension/LoopWidgets.swift
+index 26f92edb..684bf073 100644
+--- a/Loop/Loop Widget Extension/LoopWidgets.swift	
++++ b/Loop/Loop Widget Extension/LoopWidgets.swift	
+@@ -14,5 +14,6 @@ struct LoopWidgets: WidgetBundle {
+     @WidgetBundleBuilder
+     var body: some Widget {
+         SystemStatusWidget()
++        GlucoseLiveActivityConfiguration()
+     }
+ }
+diff --git a/Loop/Loop.xcodeproj/project.pbxproj b/Loop/Loop.xcodeproj/project.pbxproj
+index 11819516..15966e4b 100644
+--- a/Loop/Loop.xcodeproj/project.pbxproj
++++ b/Loop/Loop.xcodeproj/project.pbxproj
+@@ -391,6 +391,23 @@
+ 		B4E96D5D248A82A2002DABAD /* StatusBarHUDView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B4E96D5C248A82A2002DABAD /* StatusBarHUDView.xib */; };
+ 		B4F3D25124AF890C0095CE44 /* BluetoothStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3D25024AF890C0095CE44 /* BluetoothStateManager.swift */; };
+ 		B4FEEF7D24B8A71F00A8DF9B /* DeviceDataManager+DeviceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FEEF7C24B8A71F00A8DF9B /* DeviceDataManager+DeviceStatus.swift */; };
++		B813C5682C9C30B400306DAF /* QuickStatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B813C5672C9C30B400306DAF /* QuickStatsViewModel.swift */; };
++		B813C56C2C9C30DC00306DAF /* QuickStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B813C56B2C9C30DC00306DAF /* QuickStatsView.swift */; };
++		B82181F62C93628300478A91 /* LiveActivityManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82181F52C93628300478A91 /* LiveActivityManagementViewModel.swift */; };
++		B82182002C93716A00478A91 /* ChartAxisGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82181F92C936AD600478A91 /* ChartAxisGenerator.swift */; };
++		B851FFC52C37221800D738C1 /* LiveActivityManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B851FFC42C37221800D738C1 /* LiveActivityManagementView.swift */; };
++		B851FFCA2C3731DE00D738C1 /* LiveActivitySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B851FFC62C37271E00D738C1 /* LiveActivitySettings.swift */; };
++		B851FFCB2C3731DE00D738C1 /* LiveActivitySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B851FFC62C37271E00D738C1 /* LiveActivitySettings.swift */; };
++		B87539C92C2B06CE0085A975 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87539C82C2B06CE0085A975 /* LocalizedString.swift */; };
++		B87539CB2C2B08430085A975 /* Bootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87539CA2C2B08430085A975 /* Bootstrap.swift */; };
++		B87539CD2C2B46950085A975 /* ChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87539CC2C2B46950085A975 /* ChartView.swift */; };
++		B87539CF2C2DCB770085A975 /* BasalViewActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87539CE2C2DCB770085A975 /* BasalViewActivity.swift */; };
++		B87D411D2C28A69600120877 /* GlucoseLiveActivityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87D411C2C28A69600120877 /* GlucoseLiveActivityConfiguration.swift */; };
++		B87D411F2C28A85F00120877 /* ActivityKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B87D411E2C28A85F00120877 /* ActivityKit.framework */; };
++		B8A937B82C29BA5900E38645 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A937B72C29BA5900E38645 /* LiveActivityManager.swift */; };
++		B8A937C32C29C3B400E38645 /* GlucoseActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A937C02C29C29300E38645 /* GlucoseActivityAttributes.swift */; };
++		B8A937C42C29C43B00E38645 /* GlucoseActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A937C02C29C29300E38645 /* GlucoseActivityAttributes.swift */; };
++		B8FD0B522C39CA3E003FB72B /* LiveActivityBottomRowManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FD0B512C39CA3E003FB72B /* LiveActivityBottomRowManagerView.swift */; };
+ 		B66D1F212E6A5D6500471149 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B66D1F202E6A5D6500471149 /* InfoPlist.xcstrings */; };
+ 		B66D1F232E6A5D6500471149 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B66D1F222E6A5D6500471149 /* InfoPlist.xcstrings */; };
+ 		B66D1F252E6A5D6500471149 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B66D1F242E6A5D6500471149 /* InfoPlist.xcstrings */; };
+@@ -729,6 +746,16 @@
+ 			name = "Embed App Extensions";
+ 			runOnlyForDeploymentPostprocessing = 0;
+ 		};
++		B82181FF2C9370F800478A91 /* Embed Frameworks */ = {
++			isa = PBXCopyFilesBuildPhase;
++			buildActionMask = 2147483647;
++			dstPath = "";
++			dstSubfolderSpec = 10;
++			files = (
++			);
++			name = "Embed Frameworks";
++			runOnlyForDeploymentPostprocessing = 0;
++		};
+ 		C1E3DC4828595FAA00CA19FF /* Embed Frameworks */ = {
+ 			isa = PBXCopyFilesBuildPhase;
+ 			buildActionMask = 2147483647;
+@@ -1179,6 +1206,21 @@
+ 		B4E96D5C248A82A2002DABAD /* StatusBarHUDView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatusBarHUDView.xib; sourceTree = "<group>"; };
+ 		B4F3D25024AF890C0095CE44 /* BluetoothStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothStateManager.swift; sourceTree = "<group>"; };
+ 		B4FEEF7C24B8A71F00A8DF9B /* DeviceDataManager+DeviceStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeviceDataManager+DeviceStatus.swift"; sourceTree = "<group>"; };
++		B813C5672C9C30B400306DAF /* QuickStatsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStatsViewModel.swift; sourceTree = "<group>"; };
++		B813C56B2C9C30DC00306DAF /* QuickStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStatsView.swift; sourceTree = "<group>"; };
++		B82181F52C93628300478A91 /* LiveActivityManagementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManagementViewModel.swift; sourceTree = "<group>"; };
++		B82181F92C936AD600478A91 /* ChartAxisGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartAxisGenerator.swift; sourceTree = "<group>"; };
++		B851FFC42C37221800D738C1 /* LiveActivityManagementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManagementView.swift; sourceTree = "<group>"; };
++		B851FFC62C37271E00D738C1 /* LiveActivitySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivitySettings.swift; sourceTree = "<group>"; };
++		B87539C82C2B06CE0085A975 /* LocalizedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedString.swift; sourceTree = "<group>"; };
++		B87539CA2C2B08430085A975 /* Bootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bootstrap.swift; sourceTree = "<group>"; };
++		B87539CC2C2B46950085A975 /* ChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartView.swift; sourceTree = "<group>"; };
++		B87539CE2C2DCB770085A975 /* BasalViewActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasalViewActivity.swift; sourceTree = "<group>"; };
++		B87D411C2C28A69600120877 /* GlucoseLiveActivityConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseLiveActivityConfiguration.swift; sourceTree = "<group>"; };
++		B87D411E2C28A85F00120877 /* ActivityKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ActivityKit.framework; path = System/Library/Frameworks/ActivityKit.framework; sourceTree = SDKROOT; };
++		B8A937B72C29BA5900E38645 /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
++		B8A937C02C29C29300E38645 /* GlucoseActivityAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlucoseActivityAttributes.swift; sourceTree = "<group>"; };
++		B8FD0B512C39CA3E003FB72B /* LiveActivityBottomRowManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityBottomRowManagerView.swift; sourceTree = "<group>"; };
+ 		B66D1F202E6A5D6500471149 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+ 		B66D1F222E6A5D6500471149 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+ 		B66D1F242E6A5D6500471149 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+@@ -1727,6 +1769,7 @@
+ 				1419606928D9554E00BA86E0 /* LoopKitUI.framework in Frameworks */,
+ 				1419606A28D955BC00BA86E0 /* MockKitUI.framework in Frameworks */,
+ 				1481F9BB28DA26F4004C5AEB /* LoopUI.framework in Frameworks */,
++				B87D411F2C28A85F00120877 /* ActivityKit.framework in Frameworks */,
+ 				1419606428D9550400BA86E0 /* LoopKitUI.framework in Frameworks */,
+ 			);
+ 			runOnlyForDeploymentPostprocessing = 0;
+@@ -1836,6 +1879,7 @@
+ 				84AA81D12A4A2778000B658B /* Components */,
+ 				84AA81D92A4A2966000B658B /* Helpers */,
+ 				84AA81DE2A4A2B3D000B658B /* Timeline */,
++				B87D41192C28A61900120877 /* Live Activity */,
+ 				84AA81DF2A4A2B7A000B658B /* Widgets */,
+ 				84AA81D22A4A27A3000B658B /* LoopWidgets.swift */,
+ 			);
+@@ -2163,6 +2207,7 @@
+ 				43DE92581C5479E4001FFDE1 /* PotentialCarbEntryUserInfo.swift */,
+ 				43C05CB721EBEA54006FB252 /* HKUnit.swift */,
+ 				434FF1E91CF26C29000DB779 /* IdentifiableClass.swift */,
++				E9C00EEF24C620EF00628F35 /* LoopSettings.swift */,
+ 				C19E96DD23D2733F003F79B0 /* LoopCompletionFreshness.swift */,
+ 				430B29892041F54A00BA9F93 /* NSUserDefaults.swift */,
+ 				431E73471FF95A900069B5F7 /* PersistenceController.swift */,
+@@ -2170,10 +2215,10 @@
+ 				43D9FFD121EAE05D00AF44BF /* LoopCore.h */,
+ 				43D9FFD221EAE05D00AF44BF /* Info.plist */,
+ 				B66D1F3A2E6A5D6600471149 /* Localizable.xcstrings */,
+-				E9C00EEF24C620EF00628F35 /* LoopSettings.swift */,
+ 				C16575742539FD60004AE16E /* LoopCoreConstants.swift */,
+ 				E9B3551B292844010076AB04 /* MissedMealNotification.swift */,
+ 				C1D0B62F2986D4D90098D215 /* LocalizedString.swift */,
++				B851FFC62C37271E00D738C1 /* LiveActivitySettings.swift */,
+ 			);
+ 			path = LoopCore;
+ 			sourceTree = "<group>";
+@@ -2276,6 +2321,8 @@
+ 				C1AF062229426300002C1B19 /* ManualGlucoseEntryRow.swift */,
+ 				DDC389FD2A2C4C830066E2E8 /* GlucoseBasedApplicationFactorSelectionView.swift */,
+ 				DD3DBD282A33AFE9000F8B5B /* IntegralRetrospectiveCorrectionSelectionView.swift */,
++				B851FFC42C37221800D738C1 /* LiveActivityManagementView.swift */,
++				B8FD0B512C39CA3E003FB72B /* LiveActivityBottomRowManagerView.swift */,
+ 			);
+ 			path = Views;
+ 			sourceTree = "<group>";
+@@ -2315,6 +2362,7 @@
+ 				1DA6499D2441266400F61E75 /* Alerts */,
+ 				E95D37FF24EADE68005E2F50 /* Store Protocols */,
+ 				E9B355232935906B0076AB04 /* Missed Meal Detection */,
++				B8A937C52C29C44600E38645 /* Live Activity */,
+ 				C1F2075B26D6F9B0007AB7EB /* AppExpirationAlerter.swift */,
+ 				A96DAC2B2838F31200D94E38 /* SharedLogging.swift */,
+ 				7E69CFFB2A16A77E00203CBD /* ResetLoopManager.swift */,
+@@ -2525,6 +2573,7 @@
+ 				B66D1F2E2E6A5D6600471149 /* InfoPlist.xcstrings */,
+ 				14B1736D28AEDA63006CCD7C /* LoopWidgetExtension.entitlements */,
+ 				14B1736628AED9EE006CCD7C /* Info.plist */,
++				B87539CA2C2B08430085A975 /* Bootstrap.swift */,
+ 			);
+ 			path = Bootstrap;
+ 			sourceTree = "<group>";
+@@ -2535,6 +2584,7 @@
+ 				84AA81DA2A4A2973000B658B /* Date.swift */,
+ 				84AA81D52A4A28AF000B658B /* WidgetBackground.swift */,
+ 				84D2879E2AC756C8007ED283 /* ContentMargin.swift */,
++				B87539C82C2B06CE0085A975 /* LocalizedString.swift */,
+ 			);
+ 			path = Helpers;
+ 			sourceTree = "<group>";
+@@ -2628,6 +2678,7 @@
+ 				1D49795724E7289700948F05 /* ServicesViewModel.swift */,
+ 				C174233B259BEB0F00399C9D /* ManualEntryDoseViewModel.swift */,
+ 				1DB619AB270BAD3D006C9D07 /* VersionUpdateViewModel.swift */,
++				B82181F52C93628300478A91 /* LiveActivityManagementViewModel.swift */,
+ 			);
+ 			path = "View Models";
+ 			sourceTree = "<group>";
+@@ -2663,6 +2714,7 @@
+ 		968DCD53F724DE56FFE51920 /* Frameworks */ = {
+ 			isa = PBXGroup;
+ 			children = (
++				B87D411E2C28A85F00120877 /* ActivityKit.framework */,
+ 				C159C82E286787EF00A86EC0 /* LoopKit.framework */,
+ 				C159C8212867859800A86EC0 /* MockKitUI.framework */,
+ 				C159C8192867857000A86EC0 /* LoopKitUI.framework */,
+@@ -2760,6 +2812,26 @@
+ 			path = LoopCore;
+ 			sourceTree = "<group>";
+ 		};
++		B87D41192C28A61900120877 /* Live Activity */ = {
++			isa = PBXGroup;
++			children = (
++				B87D411C2C28A69600120877 /* GlucoseLiveActivityConfiguration.swift */,
++				B87539CC2C2B46950085A975 /* ChartView.swift */,
++				B87539CE2C2DCB770085A975 /* BasalViewActivity.swift */,
++			);
++			path = "Live Activity";
++			sourceTree = "<group>";
++		};
++		B8A937C52C29C44600E38645 /* Live Activity */ = {
++			isa = PBXGroup;
++			children = (
++				B8A937B72C29BA5900E38645 /* LiveActivityManager.swift */,
++				B8A937C02C29C29300E38645 /* GlucoseActivityAttributes.swift */,
++				B82181F92C936AD600478A91 /* ChartAxisGenerator.swift */,
++			);
++			path = "Live Activity";
++			sourceTree = "<group>";
++		};
+ 		C13072B82A76AF0A009A7C58 /* live_capture */ = {
+ 			isa = PBXGroup;
+ 			children = (
+@@ -2982,6 +3054,7 @@
+ 				14B1735828AED9EC006CCD7C /* Sources */,
+ 				14B1735928AED9EC006CCD7C /* Frameworks */,
+ 				14B1735A28AED9EC006CCD7C /* Resources */,
++				B82181FF2C9370F800478A91 /* Embed Frameworks */,
+ 			);
+ 			buildRules = (
+ 			);
+@@ -2989,6 +3062,8 @@
+ 				1481F9BE28DA26F4004C5AEB /* PBXTargetDependency */,
+ 			);
+ 			name = "Loop Widget Extension";
++			packageProductDependencies = (
++			);
+ 			productName = SmallStatusWidgetExtension;
+ 			productReference = 14B1735C28AED9EC006CCD7C /* Loop Widget Extension.appex */;
+ 			productType = "com.apple.product-type.app-extension";
+@@ -3623,12 +3698,15 @@
+ 			isa = PBXSourcesBuildPhase;
+ 			buildActionMask = 2147483647;
+ 			files = (
++				B87539CB2C2B08430085A975 /* Bootstrap.swift in Sources */,
+ 				14B1738128AEDC70006CCD7C /* StatusExtensionContext.swift in Sources */,
+ 				14B1737628AEDC6C006CCD7C /* HKUnit.swift in Sources */,
+ 				14B1737728AEDC6C006CCD7C /* NSBundle.swift in Sources */,
+ 				84AA81D62A4A28AF000B658B /* WidgetBackground.swift in Sources */,
+ 				84AA81D82A4A2910000B658B /* StatusWidgetTimelimeEntry.swift in Sources */,
+ 				84AA81D32A4A27A3000B658B /* LoopWidgets.swift in Sources */,
++				B87539CF2C2DCB770085A975 /* BasalViewActivity.swift in Sources */,
++				B87539CD2C2B46950085A975 /* ChartView.swift in Sources */,
+ 				84AA81E32A4A36FB000B658B /* SystemActionLink.swift in Sources */,
+ 				14B1737828AEDC6C006CCD7C /* NSTimeInterval.swift in Sources */,
+ 				14B1737928AEDC6C006CCD7C /* NSUserDefaults+StatusExtension.swift in Sources */,
+@@ -3639,7 +3717,10 @@
+ 				14B1737E28AEDC6C006CCD7C /* FeatureFlags.swift in Sources */,
+ 				84AA81E72A4A4DEF000B658B /* PumpView.swift in Sources */,
+ 				14B1737F28AEDC6C006CCD7C /* PluginManager.swift in Sources */,
++				B87D411D2C28A69600120877 /* GlucoseLiveActivityConfiguration.swift in Sources */,
++				B87539C92C2B06CE0085A975 /* LocalizedString.swift in Sources */,
+ 				14B1738028AEDC6C006CCD7C /* Debug.swift in Sources */,
++				B8A937C42C29C43B00E38645 /* GlucoseActivityAttributes.swift in Sources */,
+ 				84AA81DB2A4A2973000B658B /* Date.swift in Sources */,
+ 				14B1737228AEDBF6006CCD7C /* BasalView.swift in Sources */,
+ 				14B1737428AEDBF6006CCD7C /* GlucoseView.swift in Sources */,
+@@ -3725,6 +3806,7 @@
+ 				B4E202302661063E009421B5 /* AutomaticDosingStatus.swift in Sources */,
+ 				C191D2A125B3ACAA00C26C0B /* DosingStrategySelectionView.swift in Sources */,
+ 				A977A2F424ACFECF0059C207 /* CriticalEventLogExportManager.swift in Sources */,
++				B8FD0B522C39CA3E003FB72B /* LiveActivityBottomRowManagerView.swift in Sources */,
+ 				89CA2B32226C18B8004D9350 /* TestingScenariosTableViewController.swift in Sources */,
+ 				43E93FB71E469A5100EAB8DB /* HKUnit.swift in Sources */,
+ 				43C05CAF21EB2C24006FB252 /* NSBundle.swift in Sources */,
+@@ -3732,6 +3814,7 @@
+ 				A967D94C24F99B9300CDDF8A /* OutputStream.swift in Sources */,
+ 				1DB1065124467E18005542BD /* AlertManager.swift in Sources */,
+ 				1D9650C82523FBA100A1370B /* DeviceDataManager+BolusEntryViewModelDelegate.swift in Sources */,
++				B851FFC52C37221800D738C1 /* LiveActivityManagementView.swift in Sources */,
+ 				43C0944A1CACCC73001F6403 /* NotificationManager.swift in Sources */,
+ 				149A28E42A8A63A700052EDF /* FavoriteFoodDetailView.swift in Sources */,
+ 				1DDE274024AEA4F200796622 /* NotificationsCriticalAlertPermissionsView.swift in Sources */,
+@@ -3786,6 +3869,7 @@
+ 				C1AF062329426300002C1B19 /* ManualGlucoseEntryRow.swift in Sources */,
+ 				C148CEE724FD91BD00711B3B /* DeliveryUncertaintyAlertManager.swift in Sources */,
+ 				DDC389FC2A2BC6670066E2E8 /* SettingsView+algorithmExperimentsSection.swift in Sources */,
++				B82181F62C93628300478A91 /* LiveActivityManagementViewModel.swift in Sources */,
+ 				1D12D3B92548EFDD00B53E8B /* main.swift in Sources */,
+ 				435400341C9F878D00D5819C /* SetBolusUserInfo.swift in Sources */,
+ 				A9DCF32A25B0FABF00C89088 /* LoopUIColorPalette+Default.swift in Sources */,
+@@ -3818,11 +3902,13 @@
+ 				A97F250825E056D500F0EE19 /* OnboardingManager.swift in Sources */,
+ 				438D42F91D7C88BC003244B0 /* PredictionInputEffect.swift in Sources */,
+ 				892A5D692230C41D008961AB /* RangeReplaceableCollection.swift in Sources */,
++				B8A937B82C29BA5900E38645 /* LiveActivityManager.swift in Sources */,
+ 				DDC389F62A2B61750066E2E8 /* ApplicationFactorStrategy.swift in Sources */,
+ 				4F70C2101DE8FAC5006380B7 /* ExtensionDataManager.swift in Sources */,
+ 				43DFB62320D4CAE7008A7BAE /* PumpManager.swift in Sources */,
+ 				A9FB75F1252BE320004C7D3F /* BolusDosingDecision.swift in Sources */,
+ 				892A5D59222F0A27008961AB /* Debug.swift in Sources */,
++				B82182002C93716A00478A91 /* ChartAxisGenerator.swift in Sources */,
+ 				431A8C401EC6E8AB00823B9C /* CircleMaskView.swift in Sources */,
+ 				1D05219D2469F1F5000EBBDE /* AlertStore.swift in Sources */,
+ 				439897371CD2F80600223065 /* AnalyticsServicesManager.swift in Sources */,
+@@ -3835,6 +3921,7 @@
+ 				439706E622D2E84900C81566 /* PredictionSettingTableViewCell.swift in Sources */,
+ 				430D85891F44037000AF2D4F /* HUDViewTableViewCell.swift in Sources */,
+ 				43A51E211EB6DBDD000736CC /* LoopChartsTableViewController.swift in Sources */,
++				B8A937C32C29C3B400E38645 /* GlucoseActivityAttributes.swift in Sources */,
+ 				8968B1122408B3520074BB48 /* UIFont.swift in Sources */,
+ 				1452F4A92A851C9400F8B9E4 /* AddEditFavoriteFoodViewModel.swift in Sources */,
+ 				438D42FB1D7D11A4003244B0 /* PredictionInputEffectTableViewCell.swift in Sources */,
+@@ -3956,6 +4043,7 @@
+ 				C17DDC9D28AC33A1005FBF4C /* PersistedProperty.swift in Sources */,
+ 				43C05CA921EB2B26006FB252 /* PersistenceController.swift in Sources */,
+ 				A9CE912224CA032E00302A40 /* NSUserDefaults.swift in Sources */,
++				B851FFCB2C3731DE00D738C1 /* LiveActivitySettings.swift in Sources */,
+ 				43C05CAB21EB2B4A006FB252 /* NSBundle.swift in Sources */,
+ 				43C05CC721EC2ABC006FB252 /* IdentifiableClass.swift in Sources */,
+ 				E9B3552B293591E70076AB04 /* MissedMealNotification.swift in Sources */,
+@@ -3977,6 +4065,7 @@
+ 				C17DDC9C28AC339E005FBF4C /* PersistedProperty.swift in Sources */,
+ 				43C05CA821EB2B26006FB252 /* PersistenceController.swift in Sources */,
+ 				43C05CAA21EB2B49006FB252 /* NSBundle.swift in Sources */,
++				B851FFCA2C3731DE00D738C1 /* LiveActivitySettings.swift in Sources */,
+ 				43C05CC821EC2ABC006FB252 /* IdentifiableClass.swift in Sources */,
+ 				43C05CAD21EB2BBF006FB252 /* NSUserDefaults.swift in Sources */,
+ 				E9B3552A293591E70076AB04 /* MissedMealNotification.swift in Sources */,
+@@ -4832,6 +4921,7 @@
+ 				INFOPLIST_FILE = "Loop Widget Extension/Bootstrap/Info.plist";
+ 				INFOPLIST_KEY_CFBundleDisplayName = "Loop Widgets";
+ 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 LoopKit Authors. All rights reserved.";
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+@@ -4880,6 +4970,7 @@
+ 				INFOPLIST_FILE = "Loop Widget Extension/Bootstrap/Info.plist";
+ 				INFOPLIST_KEY_CFBundleDisplayName = "Loop Widgets";
+ 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 LoopKit Authors. All rights reserved.";
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+@@ -5138,6 +5229,7 @@
+ 				DEVELOPMENT_TEAM = "$(LOOP_DEVELOPMENT_TEAM)";
+ 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+ 				INFOPLIST_FILE = Loop/Info.plist;
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+@@ -5167,6 +5259,7 @@
+ 				DEVELOPMENT_TEAM = "$(LOOP_DEVELOPMENT_TEAM)";
+ 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+ 				INFOPLIST_FILE = Loop/Info.plist;
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+@@ -5423,6 +5516,7 @@
+ 				DEVELOPMENT_TEAM = "$(LOOP_DEVELOPMENT_TEAM)";
+ 				ENABLE_BITCODE = NO;
+ 				INFOPLIST_FILE = "Loop Status Extension/Info.plist";
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+@@ -5449,6 +5543,7 @@
+ 				DEVELOPMENT_TEAM = "$(LOOP_DEVELOPMENT_TEAM)";
+ 				ENABLE_BITCODE = NO;
+ 				INFOPLIST_FILE = "Loop Status Extension/Info.plist";
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+@@ -5516,6 +5611,7 @@
+ 				ENABLE_BITCODE = NO;
+ 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+ 				INFOPLIST_FILE = "Loop Intent Extension/Info.plist";
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+@@ -5543,6 +5639,7 @@
+ 				ENABLE_BITCODE = NO;
+ 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+ 				INFOPLIST_FILE = "Loop Intent Extension/Info.plist";
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+diff --git a/Loop/Loop/Info.plist b/Loop/Loop/Info.plist
+index ddad5426..f9f4ca84 100644
+--- a/Loop/Loop/Info.plist
++++ b/Loop/Loop/Info.plist
+@@ -71,6 +71,10 @@
+ 	<string>Carbohydrate meal data entered in the app and on the watch is stored in the Health database. Glucose data retrieved from the CGM is stored securely in HealthKit.</string>
+ 	<key>NSSiriUsageDescription</key>
+ 	<string>Loop uses Siri to allow you to enact presets with your voice.</string>
++	<key>NSSupportsLiveActivities</key>
++	<true/>
++	<key>NSSupportsLiveActivitiesFrequentUpdates</key>
++	<true/>
+ 	<key>NSUserActivityTypes</key>
+ 	<array>
+ 		<string>EnableOverridePresetIntent</string>
+diff --git a/Loop/Loop/Loop.entitlements b/Loop/Loop/Loop.entitlements
+index 50ba55d9..e6a2f9b9 100644
+--- a/Loop/Loop/Loop.entitlements
++++ b/Loop/Loop/Loop.entitlements
+@@ -8,6 +8,8 @@
+ 	<true/>
+ 	<key>com.apple.developer.healthkit.access</key>
+ 	<array/>
++	<key>com.apple.developer.healthkit.background-delivery</key>
++	<true/>
+ 	<key>com.apple.developer.nfc.readersession.formats</key>
+ 	<array>
+ 		<string>TAG</string>
+diff --git a/Loop/Loop/Managers/Live Activity/ChartAxisGenerator.swift b/Loop/Loop/Managers/Live Activity/ChartAxisGenerator.swift
+new file mode 100644
+index 00000000..0fcc3ca8
+--- /dev/null
++++ b/Loop/Loop/Managers/Live Activity/ChartAxisGenerator.swift	
+@@ -0,0 +1,125 @@
++//
++//  ChartAxisGenerator.swift
++//  Loop
++//
++//  Created by Bastiaan Verhaar on 12/09/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import HealthKit
++import SwiftCharts
++import UIKit
++
++struct ChartAxisGenerator {
++    private static let yAxisStepSizeMGDLOverride: Double? = FeatureFlags.predictedGlucoseChartClampEnabled ? 40 : nil
++    private static let range = FeatureFlags.predictedGlucoseChartClampEnabled ? LoopConstants.glucoseChartDefaultDisplayBoundClamped : LoopConstants.glucoseChartDefaultDisplayBound
++    private static let predictedGlucoseSoftBoundsMinimum = FeatureFlags.predictedGlucoseChartClampEnabled ? HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 40) : nil
++    
++    private static let minSegmentCount: Double = 2
++    private static let addPaddingSegmentIfEdge = false
++    private static let axisLabelSettings = ChartLabelSettings(font: .systemFont(ofSize: 14), fontColor: UIColor.secondaryLabel)
++    
++    // This logic is copied/ported from generateYAxisValuesUsingLinearSegmentStep
++    static func getYAxis(points: [Double], isMmol: Bool) -> [Double] {
++        let unit: HKUnit = isMmol ? .millimolesPerLiter : .milligramsPerDeciliter
++
++        let glucoseDisplayRange = [
++            range.lowerBound.doubleValue(for: unit),
++            range.upperBound.doubleValue(for: unit)
++        ]
++        
++        let actualPoints = points + glucoseDisplayRange
++        let sortedChartPoints = actualPoints.sorted {(obj1, obj2) in
++            return obj1 < obj2
++        }
++        
++        guard let first = sortedChartPoints.first, let lastPar = sortedChartPoints.last else {
++            print("Trying to generate Y axis without datapoints, returning empty array")
++            return []
++        }
++        
++        let maxSegmentCount: Double = glucoseValueBelowSoftBoundsMinimum(first, unit) ? 5 : 4
++        
++        guard lastPar >=~ first else {fatalError("Invalid range generating axis values")}
++        let multiple: Double = !isMmol ? (yAxisStepSizeMGDLOverride ?? 25) : 1
++        
++        let last = needsToAddOne(lastPar, first) ? lastPar + 1 : lastPar
++        
++        /// The first axis value will be less than or equal to the first scalar value, aligned with the desired multiple
++        var firstValue = first - (first.truncatingRemainder(dividingBy: multiple))
++        /// The last axis value will be greater than or equal to the last scalar value, aligned with the desired multiple
++        let remainder = last.truncatingRemainder(dividingBy: multiple)
++        var lastValue = remainder == 0 ? last : last + (multiple - remainder)
++        var segmentSize = multiple
++        
++        /// If there should be a padding segment added when a scalar value falls on the first or last axis value, adjust the first and last axis values
++        if firstValue =~ first && addPaddingSegmentIfEdge {
++           firstValue = firstValue - segmentSize
++        }
++        
++        // do not allow the first label to be displayed as -0
++        while firstValue < 0 && firstValue.rounded() == -0 {
++            firstValue = firstValue - segmentSize
++        }
++        
++        if lastValue =~ last && addPaddingSegmentIfEdge {
++            lastValue = lastValue + segmentSize
++        }
++        
++        let distance = lastValue - firstValue
++        var currentMultiple = multiple
++        var segmentCount = distance / currentMultiple
++        var potentialSegmentValues = stride(from: firstValue, to: lastValue, by: currentMultiple)
++
++        /// Find the optimal number of segments and segment width
++        /// If the number of segments is greater than desired, make each segment wider
++        /// ensure no label of -0 will be displayed on the axis
++        while segmentCount > maxSegmentCount ||
++            !potentialSegmentValues.filter({ $0 < 0 && $0.rounded() == -0 }).isEmpty
++        {
++            currentMultiple += multiple
++            segmentCount = distance / currentMultiple
++            potentialSegmentValues = stride(from: firstValue, to: lastValue, by: currentMultiple)
++        }
++        segmentCount = ceil(segmentCount)
++        
++        /// Increase the number of segments until there are enough as desired
++        while segmentCount < minSegmentCount {
++            segmentCount += 1
++        }
++        segmentSize = currentMultiple
++        
++        /// Generate axis values from the first value, segment size and number of segments
++        let offset = firstValue
++        return (0...Int(segmentCount)).map {segment in
++            var scalar = offset + (Double(segment) * segmentSize)
++            // a value that could be displayed as 0 should truly be 0 to have the zero-line drawn correctly.
++            if scalar != 0,
++                scalar.rounded() == 0
++            {
++                scalar = 0
++            }
++            return ChartAxisValueDouble(scalar, labelSettings: axisLabelSettings).scalar
++        }
++    }
++    
++    private static func needsToAddOne(_ a: Double, _ b: Double) -> Bool {
++        return fabs(a - b) < Double.ulpOfOne
++    }
++    
++    private static func glucoseValueBelowSoftBoundsMinimum(_ glucoseMinimum: Double, _ unit: HKUnit) -> Bool {
++        guard let predictedGlucoseSoftBoundsMinimum = predictedGlucoseSoftBoundsMinimum else
++        {
++            return false
++        }
++            
++        return HKQuantity(unit: unit, doubleValue: glucoseMinimum) < predictedGlucoseSoftBoundsMinimum
++    }
++}
++
++fileprivate extension Double {
++    static func >=~ (a: Double, b: Double) -> Bool {
++        return a =~ b || a > b
++    }
++}
+diff --git a/Loop/Loop/Managers/Live Activity/GlucoseActivityAttributes.swift b/Loop/Loop/Managers/Live Activity/GlucoseActivityAttributes.swift
+new file mode 100644
+index 00000000..936de751
+--- /dev/null
++++ b/Loop/Loop/Managers/Live Activity/GlucoseActivityAttributes.swift	
+@@ -0,0 +1,151 @@
++//
++//  LiveActivityAttributes.swift
++//  LoopUI
++//
++//  Created by Bastiaan Verhaar on 23/06/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import ActivityKit
++import Foundation
++import LoopKit
++import LoopCore
++
++public struct GlucoseActivityAttributes: ActivityAttributes {
++    public struct ContentState: Codable, Hashable {
++        // Meta data
++        public let date: Date
++        public let ended: Bool
++        public let preset: Preset?
++        public let glucoseRanges: [GlucoseRangeValue]
++        
++        // Dynamic island data
++        public let currentGlucose: Double
++        public let trendType: GlucoseTrend?
++        public let delta: String
++        public let isMmol: Bool
++        
++        // Loop circle
++        public let isCloseLoop: Bool
++        public let lastCompleted: Date?
++        
++        // Bottom row
++        public let bottomRow: [BottomRowItem]
++        
++        // Chart view
++        public let glucoseSamples: [GlucoseSampleAttributes]
++        public let predicatedGlucose: [Double]
++        public let predicatedStartDate: Date?
++        public let predicatedInterval: TimeInterval?
++        public let yAxisMarks: [Double]
++    }
++    
++    public let mode: LiveActivityMode
++    public let addPredictiveLine: Bool
++    public let useLimits: Bool
++    public let upperLimitChartMmol: Double
++    public let lowerLimitChartMmol: Double
++    public let upperLimitChartMg: Double
++    public let lowerLimitChartMg: Double
++}
++
++public struct Preset: Codable, Hashable {
++    public let title: String
++    public let startDate: Date
++    public let endDate: Date
++    public let minValue: Double
++    public let maxValue: Double
++}
++
++public struct GlucoseRangeValue: Identifiable, Codable, Hashable {
++    public let id: UUID
++    public let minValue: Double
++    public let maxValue: Double
++    public let startDate: Date
++    public let endDate: Date
++}
++
++public struct BottomRowItem: Codable, Hashable {
++    public enum BottomRowType: Codable, Hashable {
++        case generic
++        case basal
++        case currentBg
++        case loopCircle
++    }
++    
++    public let type: BottomRowType
++    
++    // Generic properties
++    public let label: String
++    public let value: String
++    public let unit: String
++    
++    public let trend: GlucoseTrend?
++
++    // Basal properties
++    public let rate: Double
++    public let percentage: Double
++    
++    private init(type: BottomRowType, label: String?, value: String?, unit: String?, trend: GlucoseTrend?, rate: Double?, percentage: Double?) {
++        self.type = type
++        self.label = label ?? ""
++        self.value = value ?? ""
++        self.trend = trend
++        self.unit = unit ?? ""
++        self.rate = rate ?? 0
++        self.percentage = percentage ?? 0
++    }
++    
++    static func generic(label: String, value: String, unit: String) -> BottomRowItem  {
++        return BottomRowItem(
++            type: .generic,
++            label: label,
++            value: value,
++            unit: unit,
++            trend: nil,
++            rate: nil,
++            percentage: nil
++        )
++    }
++    
++    static func basal(rate: Double, percentage: Double) -> BottomRowItem {
++        return BottomRowItem(
++            type: .basal,
++            label: nil,
++            value: nil,
++            unit: nil,
++            trend: nil,
++            rate: rate,
++            percentage: percentage
++        )
++    }
++    
++    static func currentBg(label: String, value: String, trend: GlucoseTrend?) -> BottomRowItem {
++        return BottomRowItem(
++            type: .currentBg,
++            label: label,
++            value: value,
++            unit: nil,
++            trend: trend,
++            rate: nil,
++            percentage: nil
++        )
++    }
++    
++    static func loopIcon() -> BottomRowItem {
++        return BottomRowItem(
++            type: .loopCircle,
++            label: nil,
++            value: nil,
++            unit: nil,
++            trend: nil,
++            rate: nil,
++            percentage: nil
++        )
++    }
++}
++
++public struct GlucoseSampleAttributes: Codable, Hashable {
++    public let x: Date
++    public let y: Double
++}
+diff --git a/Loop/Loop/Managers/Live Activity/LiveActivityManager.swift b/Loop/Loop/Managers/Live Activity/LiveActivityManager.swift
+new file mode 100644
+index 00000000..30c6920f
+--- /dev/null
++++ b/Loop/Loop/Managers/Live Activity/LiveActivityManager.swift	
+@@ -0,0 +1,516 @@
++//
++//  LiveActivityManaer.swift
++//  Loop
++//
++//  Created by Bastiaan Verhaar on 24/06/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import LoopKitUI
++import LoopKit
++import LoopCore
++import Foundation
++import HealthKit
++import ActivityKit
++
++extension Notification.Name {
++    static let LiveActivitySettingsChanged = Notification.Name(rawValue: "com.loopKit.notification.LiveActivitySettingsChanged")
++}
++
++@available(iOS 16.2, *)
++class LiveActivityManager {
++    private let activityInfo = ActivityAuthorizationInfo()
++    private var activity: Activity<GlucoseActivityAttributes>?
++    private let healthStore = HKHealthStore()
++    
++    private let glucoseStore: GlucoseStoreProtocol
++    private let doseStore: DoseStoreProtocol
++    private var loopSettings: LoopSettings
++    
++    private var startDate: Date = Date.now
++    private var settings: LiveActivitySettings = UserDefaults.standard.liveActivity ?? LiveActivitySettings()
++    
++    private let cobFormatter: NumberFormatter =  {
++        let numberFormatter = NumberFormatter()
++        numberFormatter.numberStyle = .none
++        return numberFormatter
++    }()
++    private let iobFormatter: NumberFormatter =  {
++        let numberFormatter = NumberFormatter()
++        numberFormatter.numberStyle = .none
++        numberFormatter.maximumFractionDigits = 1
++        numberFormatter.minimumFractionDigits = 1
++        return numberFormatter
++    }()
++    private let timeFormatter: DateFormatter = {
++        let dateFormatter = DateFormatter()
++        dateFormatter.dateStyle = .none
++        dateFormatter.timeStyle = .short
++        
++        return dateFormatter
++    }()
++    
++    init?(glucoseStore: GlucoseStoreProtocol, doseStore: DoseStoreProtocol, loopSettings: LoopSettings) {
++        guard self.activityInfo.areActivitiesEnabled else {
++            print("ERROR: Live Activities are not enabled...")
++            return nil
++        }
++        
++        self.glucoseStore = glucoseStore
++        self.doseStore = doseStore
++        self.loopSettings = loopSettings
++        
++        // Ensure settings exist
++        if UserDefaults.standard.liveActivity == nil {
++            self.settings = LiveActivitySettings()
++        }
++        
++        let nc = NotificationCenter.default
++        nc.addObserver(self, selector: #selector(self.appMovedToForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
++        nc.addObserver(self, selector: #selector(self.settingsChanged), name: .LiveActivitySettingsChanged, object: nil)
++        guard self.settings.enabled else {
++            return
++        }
++        
++        initEmptyActivity(settings: self.settings)
++        update()
++        
++        Task {
++            await self.endUnknownActivities()
++        }
++    }
++    
++    public func update(loopSettings: LoopSettings) {
++        self.loopSettings = loopSettings
++        update()
++    }
++    
++    private func update() {
++        Task {
++            if self.needsRecreation(), await UIApplication.shared.applicationState == .active {
++                // activity is no longer visible or old. End it and try to push the update again
++                await endActivity()
++            }
++            
++            guard let unit = await self.healthStore.cachedPreferredUnits(for: .bloodGlucose) else {
++                print("ERROR: No unit found...")
++                return
++            }
++            
++            let isMmol = unit == HKUnit.millimolesPerLiter
++            await self.endUnknownActivities()
++
++            let statusContext = UserDefaults.appGroup?.statusExtensionContext
++            let glucoseFormatter = NumberFormatter.glucoseFormatter(for: unit)
++            
++            let glucoseSamples = self.getGlucoseSample(unit: unit)
++            guard let currentGlucose = glucoseSamples.last else {
++                print("ERROR: No glucose sample found...")
++                return
++            }
++
++            let current = currentGlucose.quantity.doubleValue(for: unit)
++            
++            var delta: String = "+\(glucoseFormatter.string(from: Double(0)) ?? "")"
++            if glucoseSamples.count > 1 {
++                let prevSample = glucoseSamples[glucoseSamples.count - 2]
++                let deltaValue = current - (prevSample.quantity.doubleValue(for: unit))
++                delta = "\(deltaValue < 0 ? "-" : "+")\(glucoseFormatter.string(from: abs(deltaValue)) ?? "??")"
++            }
++            
++            let bottomRow = self.getBottomRow(
++                currentGlucose: current,
++                delta: delta,
++                statusContext: statusContext,
++                glucoseFormatter: glucoseFormatter
++            )
++
++            var predicatedGlucose: [Double] = []
++            if let samples = statusContext?.predictedGlucose?.values, settings.addPredictiveLine {
++                predicatedGlucose = samples
++            }
++            
++            var endDateChart: Date? = nil
++            if predicatedGlucose.count == 0 {
++                endDateChart = glucoseSamples.last?.startDate
++            } else if let predictedGlucose = statusContext?.predictedGlucose {
++                endDateChart = predictedGlucose.startDate.addingTimeInterval(.hours(4))
++            }
++            
++            guard let endDateChart = endDateChart else {
++                return
++            }
++            
++            var presetContext: Preset? = nil
++            if let override = self.loopSettings.preMealOverride ?? self.loopSettings.scheduleOverride, let start = glucoseSamples.first?.startDate {
++                presetContext = Preset(
++                    title: override.getTitle(),
++                    startDate: max(override.startDate, start),
++                    endDate: override.duration.isInfinite ? endDateChart : min(override.actualEndDate, endDateChart),
++                    minValue: override.settings.targetRange?.lowerBound.doubleValue(for: unit) ?? 0,
++                    maxValue: override.settings.targetRange?.upperBound.doubleValue(for: unit) ?? 0
++                )
++            }
++            
++            var glucoseRanges: [GlucoseRangeValue] = []
++            if let glucoseRangeSchedule = self.loopSettings.glucoseTargetRangeSchedule, let start = glucoseSamples.first?.startDate {
++                glucoseRanges = getGlucoseRanges(
++                    glucoseRangeSchedule: glucoseRangeSchedule,
++                    presetContext: presetContext,
++                    start: start,
++                    end: endDateChart,
++                    unit: unit
++                )
++            }
++            
++            let yAxisPoints = glucoseSamples.map{ item in item.quantity.doubleValue(for: unit) } + predicatedGlucose
++            let chartYAxis = ChartAxisGenerator.getYAxis(
++                points: yAxisPoints,
++                isMmol: unit == HKUnit.millimolesPerLiter
++            )
++
++            let state = GlucoseActivityAttributes.ContentState(
++                date: currentGlucose.startDate,
++                ended: false,
++                preset: presetContext,
++                glucoseRanges: glucoseRanges,
++                currentGlucose: current,
++                trendType: statusContext?.glucoseDisplay?.trendType,
++                delta: delta,
++                isMmol: isMmol,
++                isCloseLoop: statusContext?.isClosedLoop ?? false,
++                lastCompleted: statusContext?.lastLoopCompleted,
++                bottomRow: bottomRow,
++                // In order to prevent maxSize errors, only allow the last 100 samples to be sent
++                // Will most likely not be an issue, might be an issue for debugging/CGM simulator with 5sec interval
++                glucoseSamples: glucoseSamples.suffix(100).map { item in
++                    return GlucoseSampleAttributes(x: item.startDate, y: item.quantity.doubleValue(for: unit))
++                },
++                predicatedGlucose: predicatedGlucose,
++                predicatedStartDate: statusContext?.predictedGlucose?.startDate,
++                predicatedInterval: statusContext?.predictedGlucose?.interval,
++                yAxisMarks: chartYAxis
++            )
++            
++            await self.activity?.update(ActivityContent(
++                state: state,
++                staleDate: Date.now.addingTimeInterval(.hours(1))
++            ))
++        }
++    }
++    
++    @objc private func settingsChanged() {
++        Task {
++            let newSettings = UserDefaults.standard.liveActivity ?? LiveActivitySettings()
++            
++            // Update live activity if needed
++            if !newSettings.enabled, let activity = self.activity {
++                await activity.end(nil, dismissalPolicy: .immediate)
++                self.activity = nil
++                
++                return
++            } else if newSettings.enabled && self.activity == nil {
++                initEmptyActivity(settings: newSettings)
++                
++            } else if newSettings != self.settings {
++                await self.activity?.end(nil, dismissalPolicy: .immediate)
++                self.activity = nil
++                
++                initEmptyActivity(settings: newSettings)
++            }
++            
++            self.settings = newSettings
++            update()
++        }
++    }
++    
++    @objc private func appMovedToForeground() {
++        guard self.settings.enabled else {
++            return
++        }
++        
++        guard let activity = self.activity else {
++            initEmptyActivity(settings: self.settings)
++            update()
++            return
++        }
++        
++        Task {
++            await activity.end(nil, dismissalPolicy: .immediate)
++            await self.endUnknownActivities()
++            self.activity = nil
++            
++            initEmptyActivity(settings: self.settings)
++            update()
++        }
++    }
++    
++    private func endUnknownActivities() async {
++        for unknownActivity in Activity<GlucoseActivityAttributes>.activities
++            .filter({ self.activity?.id != $0.id })
++        {
++            await unknownActivity.end(nil, dismissalPolicy: .immediate)
++        }
++    }
++    
++    private func endActivity() async {
++        let dynamicState = self.activity?.content.state
++        await self.activity?.end(nil, dismissalPolicy: .immediate)
++        for unknownActivity in Activity<GlucoseActivityAttributes>.activities {
++            await unknownActivity.end(nil, dismissalPolicy: .immediate)
++        }
++        
++        do {
++            if let dynamicState = dynamicState {
++                self.activity = try Activity.request(
++                    attributes: GlucoseActivityAttributes(
++                        mode: self.settings.mode,
++                        addPredictiveLine: self.settings.addPredictiveLine,
++                        useLimits: self.settings.useLimits,
++                        upperLimitChartMmol: self.settings.upperLimitChartMmol,
++                        lowerLimitChartMmol: self.settings.lowerLimitChartMmol,
++                        upperLimitChartMg: self.settings.upperLimitChartMg,
++                        lowerLimitChartMg: self.settings.lowerLimitChartMg
++                    ),
++                    content: .init(state: dynamicState, staleDate: nil),
++                    pushType: .token
++                )
++            }
++            self.startDate = Date.now
++        } catch {
++            print("ERROR: Error while ending live activity: \(error.localizedDescription)")
++        }
++    }
++    
++    private func needsRecreation() -> Bool {
++        if !self.settings.enabled {
++            return false
++        }
++        
++        switch activity?.activityState {
++        case .dismissed,
++             .ended,
++             .stale:
++            return true
++        case .active:
++            return -startDate.timeIntervalSinceNow > .hours(1)
++        default:
++            return true
++        }
++    }
++    
++    private func getInsulinOnBoard() -> String {
++        let updateGroup = DispatchGroup()
++        var iob = "??"
++        
++        updateGroup.enter()
++        self.doseStore.insulinOnBoard(at: Date.now) { result in
++            switch (result) {
++            case .failure:
++                break
++            case .success(let iobValue):
++                iob = self.iobFormatter.string(from: iobValue.value) ?? "??"
++                break
++            }
++            
++            updateGroup.leave()
++        }
++        
++        _ = updateGroup.wait(timeout: .distantFuture)
++        return iob
++    }
++    
++    private func getGlucoseSample(unit: HKUnit) -> [StoredGlucoseSample] {
++        let updateGroup = DispatchGroup()
++        var samples: [StoredGlucoseSample] = []
++        
++        updateGroup.enter()
++        
++        // When in spacious mode, we want to show the predictive line
++        // In compact mode, we only want to show the history
++        let timeInterval: TimeInterval = self.settings.addPredictiveLine ? .hours(-2) : .hours(-6)
++        self.glucoseStore.getGlucoseSamples(
++            start: Date.now.addingTimeInterval(timeInterval),
++            end: Date.now
++        ) { result in
++            switch (result) {
++            case .failure:
++                break
++            case .success(let data):
++                samples = data
++                break
++            }
++            
++            updateGroup.leave()
++        }
++        
++        _ = updateGroup.wait(timeout: .distantFuture)
++        return samples
++    }
++    
++    private func getGlucoseRanges(glucoseRangeSchedule: GlucoseRangeSchedule, presetContext: Preset?, start: Date, end: Date, unit: HKUnit) -> [GlucoseRangeValue] {
++        var glucoseRanges: [GlucoseRangeValue] = []
++        for item in glucoseRangeSchedule.quantityBetween(start: start, end: end) {
++            let minValue = item.value.lowerBound.doubleValue(for: unit)
++            let maxValue = item.value.upperBound.doubleValue(for: unit)
++            let startDate = max(item.startDate, start)
++            let endDate = min(item.endDate, end)
++            
++            if let presetContext = presetContext {
++                if presetContext.startDate > startDate, presetContext.endDate < endDate {
++                    // A preset is active during this schedule
++                    glucoseRanges.append(GlucoseRangeValue(
++                        id: UUID(),
++                        minValue: minValue,
++                        maxValue: maxValue,
++                        startDate: startDate,
++                        endDate: presetContext.startDate
++                    ))
++                    glucoseRanges.append(GlucoseRangeValue(
++                        id: UUID(),
++                        minValue: minValue,
++                        maxValue: maxValue,
++                        startDate: presetContext.endDate,
++                        endDate: endDate
++                    ))
++                } else if presetContext.endDate > startDate, presetContext.endDate < endDate {
++                    // Cut off the start of the glucose target
++                    glucoseRanges.append(GlucoseRangeValue(
++                        id: UUID(),
++                        minValue: minValue,
++                        maxValue: maxValue,
++                        startDate: presetContext.endDate,
++                        endDate: endDate
++                    ))
++                } else if presetContext.startDate < endDate, presetContext.startDate > startDate {
++                    // Cut off the end of the glucose target
++                    glucoseRanges.append(GlucoseRangeValue(
++                        id: UUID(),
++                        minValue: minValue,
++                        maxValue: maxValue,
++                        startDate: startDate,
++                        endDate: presetContext.startDate
++                    ))
++                    if presetContext.endDate == end {
++                        break
++                    }
++                } else {
++                    // No overlap with target and override
++                    glucoseRanges.append(GlucoseRangeValue(
++                        id: UUID(),
++                        minValue: minValue,
++                        maxValue: maxValue,
++                        startDate: startDate,
++                        endDate: endDate
++                    ))
++                }
++            } else {
++                glucoseRanges.append(GlucoseRangeValue(
++                    id: UUID(),
++                    minValue: minValue,
++                    maxValue: maxValue,
++                    startDate: startDate,
++                    endDate: endDate
++                ))
++            }
++        }
++        
++        return glucoseRanges
++    }
++    
++    private func getBottomRow(currentGlucose: Double, delta: String, statusContext: StatusExtensionContext?, glucoseFormatter: NumberFormatter) -> [BottomRowItem] {
++        return self.settings.bottomRowConfiguration.map { type in
++            switch(type) {
++            case .iob:
++                return BottomRowItem.generic(label: type.name(), value: getInsulinOnBoard(), unit: "U")
++                
++            case .cob:
++                var cob: String = "0"
++                if let cobValue = statusContext?.carbsOnBoard {
++                    cob = self.cobFormatter.string(from: cobValue) ?? "??"
++                }
++                return BottomRowItem.generic(label: type.name(), value: cob, unit: "g")
++                
++            case .basal:
++                guard let netBasalContext = statusContext?.netBasal else {
++                    return BottomRowItem.basal(rate: 0, percentage: 0)
++                }
++
++                return BottomRowItem.basal(rate: netBasalContext.rate, percentage: netBasalContext.percentage)
++                
++            case .currentBg:
++                return BottomRowItem.currentBg(label: type.name(), value: "\(glucoseFormatter.string(from: currentGlucose) ?? "??")", trend: statusContext?.glucoseDisplay?.trendType)
++                
++            case .eventualBg:
++                guard let eventual = statusContext?.predictedGlucose?.values.last else {
++                    return BottomRowItem.generic(label: type.name(), value: "??", unit: "")
++                }
++                
++                return BottomRowItem.generic(label: type.name(), value: glucoseFormatter.string(from: eventual) ?? "??", unit: "")
++                
++            case .deltaBg:
++                return BottomRowItem.generic(label: type.name(), value: delta, unit: "")
++                
++            case .loopCircle:
++                return BottomRowItem.loopIcon()
++                
++            case .updatedAt:
++                return BottomRowItem.generic(label: type.name(), value: timeFormatter.string(from: Date.now), unit: "")
++            }
++       }
++    }
++    
++    private func initEmptyActivity(settings: LiveActivitySettings) {
++        do {
++            let dynamicState = GlucoseActivityAttributes.ContentState(
++                date: Date.now,
++                ended: true,
++                preset: nil,
++                glucoseRanges: [],
++                currentGlucose: 0,
++                trendType: nil,
++                delta: "",
++                isMmol: true,
++                isCloseLoop: false,
++                lastCompleted: nil,
++                bottomRow: [],
++                glucoseSamples: [],
++                predicatedGlucose: [],
++                predicatedStartDate: nil,
++                predicatedInterval: nil,
++                yAxisMarks: []
++            )
++            
++            self.activity = try Activity.request(
++                attributes: GlucoseActivityAttributes(
++                    mode: settings.mode,
++                    addPredictiveLine: settings.addPredictiveLine,
++                    useLimits: settings.useLimits,
++                    upperLimitChartMmol: settings.upperLimitChartMmol,
++                    lowerLimitChartMmol: settings.lowerLimitChartMmol,
++                    upperLimitChartMg: settings.upperLimitChartMg,
++                    lowerLimitChartMg: settings.lowerLimitChartMg
++                ),
++                content: .init(state: dynamicState, staleDate: nil),
++                pushType: .token
++            )
++        } catch {
++            print("ERROR: Error while creating empty live activity: \(error.localizedDescription)")
++        }
++    }
++}
++
++extension TemporaryScheduleOverride {
++    func getTitle() -> String {
++        switch (self.context) {
++        case .preset(let preset):
++            return "\(preset.symbol) \(preset.name)"
++        case .custom:
++            return NSLocalizedString("Custom preset", comment: "The title of the cell indicating a generic custom preset is enabled")
++        case .preMeal:
++            return NSLocalizedString(" Pre-meal Preset", comment: "Status row title for premeal override enabled (leading space is to separate from symbol)")
++        case .legacyWorkout:
++            return ""
++        }
++    }
++}
+diff --git a/Loop/Loop/Managers/LoopDataManager.swift b/Loop/Loop/Managers/LoopDataManager.swift
+index 2319f4ec..36c228c7 100644
+--- a/Loop/Loop/Managers/LoopDataManager.swift
++++ b/Loop/Loop/Managers/LoopDataManager.swift
+@@ -68,6 +68,8 @@ final class LoopDataManager {
+     private var timeBasedDoseApplicationFactor: Double = 1.0
+ 
+     private var insulinOnBoard: InsulinValue?
++    
++    private var liveActivityManager: LiveActivityManager?
+ 
+     deinit {
+         for observer in notificationObservers {
+@@ -124,6 +126,12 @@ final class LoopDataManager {
+         self.automaticDosingStatus = automaticDosingStatus
+ 
+         self.trustedTimeOffset = trustedTimeOffset
++        
++        self.liveActivityManager = LiveActivityManager(
++            glucoseStore: self.glucoseStore,
++            doseStore: self.doseStore,
++            loopSettings: self.settings
++        )
+ 
+         overrideIntentObserver = UserDefaults.appGroup?.observe(\.intentExtensionOverrideToSet, options: [.new], changeHandler: {[weak self] (defaults, change) in
+             guard let name = change.newValue??.lowercased(), let appGroup = UserDefaults.appGroup else {
+@@ -144,12 +152,14 @@ final class LoopDataManager {
+                         }
+                     }
+                 }
++                
+                 settings.scheduleOverride = preset.createOverride(enactTrigger: .remote("Siri"))
+                 if let observers = self?.presetActivationObservers {
+                     for observer in observers {
+                         observer.presetActivated(context: .preset(preset), duration: preset.duration)
+                     }
+                 }
++                self?.liveActivityManager?.update(loopSettings: settings)
+             }
+             // Remove the override from UserDefaults so we don't set it multiple times
+             appGroup.intentExtensionOverrideToSet = nil
+@@ -167,6 +177,7 @@ final class LoopDataManager {
+             ) { (note) -> Void in
+                 self.dataAccessQueue.async {
+                     self.logger.default("Received notification of carb entries changing")
++                    self.liveActivityManager?.update(loopSettings: self.settings)
+ 
+                     self.carbEffect = nil
+                     self.carbsOnBoard = nil
+@@ -182,7 +193,8 @@ final class LoopDataManager {
+             ) { (note) in
+                 self.dataAccessQueue.async {
+                     self.logger.default("Received notification of glucose samples changing")
+-
++                    self.liveActivityManager?.update(loopSettings: self.settings)
++                    
+                     self.glucoseMomentumEffect = nil
+                     self.remoteRecommendationNeedsUpdating = true
+ 
+@@ -196,6 +208,7 @@ final class LoopDataManager {
+             ) { (note) in
+                 self.dataAccessQueue.async {
+                     self.logger.default("Received notification of dosing changing")
++                    self.liveActivityManager?.update(loopSettings: self.settings)
+ 
+                     self.clearCachedInsulinEffects()
+                     self.remoteRecommendationNeedsUpdating = true
+@@ -247,6 +260,8 @@ final class LoopDataManager {
+         if newValue.preMealOverride != oldValue.preMealOverride {
+             // The prediction isn't actually invalid, but a target range change requires recomputing recommended doses
+             predictedGlucose = nil
++            
++            self.liveActivityManager?.update(loopSettings: newValue)
+         }
+ 
+         if newValue.scheduleOverride != oldValue.scheduleOverride {
+@@ -256,12 +271,14 @@ final class LoopDataManager {
+                 for observer in self.presetActivationObservers {
+                     observer.presetDeactivated(context: oldPreset.context)
+                 }
+-
++                self.liveActivityManager?.update(loopSettings: newValue)
+             }
+             if let newPreset = newValue.scheduleOverride {
+                 for observer in self.presetActivationObservers {
+                     observer.presetActivated(context: newPreset.context, duration: newPreset.duration)
+                 }
++                
++                self.liveActivityManager?.update(loopSettings: newValue)
+             }
+ 
+             // Invalidate cached effects affected by the override
+diff --git a/Loop/Loop/View Models/LiveActivityManagementViewModel.swift b/Loop/Loop/View Models/LiveActivityManagementViewModel.swift
+new file mode 100644
+index 00000000..46fc560d
+--- /dev/null
++++ b/Loop/Loop/View Models/LiveActivityManagementViewModel.swift	
+@@ -0,0 +1,35 @@
++//
++//  LiveActivityManagementViewModel.swift
++//  Loop
++//
++//  Created by Bastiaan Verhaar on 12/09/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import LoopCore
++
++class LiveActivityManagementViewModel : ObservableObject {
++    @Published var enabled: Bool
++    @Published var mode: LiveActivityMode
++    @Published var isEditingMode: Bool = false
++    @Published var addPredictiveLine: Bool
++    @Published var useLimits: Bool
++    @Published var upperLimitChartMmol: Double
++    @Published var lowerLimitChartMmol: Double
++    @Published var upperLimitChartMg: Double
++    @Published var lowerLimitChartMg: Double
++    
++    init() {
++        let liveActivitySettings = UserDefaults.standard.liveActivity ?? LiveActivitySettings()
++        
++        self.enabled = liveActivitySettings.enabled
++        self.mode = liveActivitySettings.mode
++        self.addPredictiveLine = liveActivitySettings.addPredictiveLine
++        self.useLimits = liveActivitySettings.useLimits
++        self.upperLimitChartMmol = liveActivitySettings.upperLimitChartMmol
++        self.lowerLimitChartMmol = liveActivitySettings.lowerLimitChartMmol
++        self.upperLimitChartMg = liveActivitySettings.upperLimitChartMg
++        self.lowerLimitChartMg = liveActivitySettings.lowerLimitChartMg
++    }
++}
+diff --git a/Loop/Loop/Views/AlertManagementView.swift b/Loop/Loop/Views/AlertManagementView.swift
+index e9a38e72..94e542a6 100644
+--- a/Loop/Loop/Views/AlertManagementView.swift
++++ b/Loop/Loop/Views/AlertManagementView.swift
+@@ -7,8 +7,10 @@
+ //
+ 
+ import SwiftUI
++import LoopCore
+ import LoopKit
+ import LoopKitUI
++import HealthKit
+ 
+ struct AlertManagementView: View {
+     @Environment(\.appName) private var appName
+@@ -157,6 +159,11 @@ struct AlertManagementView: View {
+                     }
+                 }
+             }
++            
++            NavigationLink(destination: LiveActivityManagementView())
++            {
++                    Text(NSLocalizedString("Live activity", comment: "Alert Permissions live activity"))
++            }
+         }
+     }
+ 
+diff --git a/Loop/Loop/Views/LiveActivityBottomRowManagerView.swift b/Loop/Loop/Views/LiveActivityBottomRowManagerView.swift
+new file mode 100644
+index 00000000..49e50caa
+--- /dev/null
++++ b/Loop/Loop/Views/LiveActivityBottomRowManagerView.swift
+@@ -0,0 +1,117 @@
++//
++//  LiveActivityBottomRowManagerView.swift
++//  Loop
++//
++//  Created by Bastiaan Verhaar on 06/07/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import LoopKitUI
++import LoopCore
++import SwiftUI
++
++struct LiveActivityBottomRowManagerView: View {
++    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
++
++    // The maximum items in the bottom row
++    private let maxSize = 4
++    
++    @State var showAdd: Bool = false
++    @State var configuration: [BottomRowConfiguration] = (UserDefaults.standard.liveActivity ?? LiveActivitySettings()).bottomRowConfiguration
++    
++    var addItem: ActionSheet {
++        var buttons: [ActionSheet.Button] = BottomRowConfiguration.all.map { item in
++            ActionSheet.Button.default(Text(item.description())) {
++                configuration.append(item)
++            }
++        }
++        buttons.append(.cancel(Text(NSLocalizedString("Cancel", comment: "Button text to cancel"))))
++        
++        return ActionSheet(title: Text(NSLocalizedString("Add item to bottom row", comment: "Title for Add item")), buttons: buttons)
++    }
++    
++    var body: some View {
++        List {
++            ForEach($configuration, id: \.self) { item in
++                HStack {
++                    deleteButton
++                        .onTapGesture {
++                            onDelete(item.wrappedValue)
++                        }
++                    Text(item.wrappedValue.description())
++                    
++                    Spacer()
++                    editBars
++                }
++            }
++                .onMove(perform: onReorder)
++                .deleteDisabled(true)
++            
++            Section {
++                Button(action: onSave) {
++                    Text(NSLocalizedString("Save", comment: ""))
++                }
++                .buttonStyle(ActionButtonStyle())
++                .listRowInsets(EdgeInsets())
++            }
++        }
++            .toolbar {
++                ToolbarItem(placement: .navigationBarTrailing) {
++                    Button(
++                        action: { showAdd = true },
++                        label: { Image(systemName: "plus") }
++                    )
++                    .disabled(configuration.count >= self.maxSize)
++                }
++            }
++            .actionSheet(isPresented: $showAdd, content: { addItem })
++            .insetGroupedListStyle()
++            .navigationBarTitle(Text(NSLocalizedString("Bottom row", comment: "Live activity Bottom row configuration title")))
++    }
++    
++    @ViewBuilder
++    private var deleteButton: some View {
++        ZStack {
++            Color.red
++                .clipShape(RoundedRectangle(cornerRadius: 12.5))
++                .frame(width: 20, height: 20)
++            
++            Image(systemName: "minus")
++                .foregroundColor(.white)
++        }
++        .contentShape(Rectangle())
++    }
++    
++    @ViewBuilder
++    private var editBars: some View {
++        Image(systemName: "line.3.horizontal")
++            .foregroundColor(Color(UIColor.tertiaryLabel))
++            .font(.title2)
++    }
++    
++    private func onSave() {
++        var settings = UserDefaults.standard.liveActivity ?? LiveActivitySettings()
++        settings.bottomRowConfiguration = configuration
++        
++        UserDefaults.standard.liveActivity = settings
++        NotificationCenter.default.post(name: .LiveActivitySettingsChanged, object: settings)
++        
++        self.presentationMode.wrappedValue.dismiss()
++    }
++    
++    func onReorder(from: IndexSet, to: Int) {
++        withAnimation {
++            configuration.move(fromOffsets: from, toOffset: to)
++        }
++    }
++    
++    func onDelete(_ item: BottomRowConfiguration) {
++        withAnimation {
++            _ = configuration.remove(item)
++        }
++    }
++}
++
++#Preview {
++    LiveActivityBottomRowManagerView()
++}
+diff --git a/Loop/Loop/Views/LiveActivityManagementView.swift b/Loop/Loop/Views/LiveActivityManagementView.swift
+new file mode 100644
+index 00000000..bdf87dc5
+--- /dev/null
++++ b/Loop/Loop/Views/LiveActivityManagementView.swift
+@@ -0,0 +1,140 @@
++//
++//  LiveActivityManagementView.swift
++//  Loop
++//
++//  Created by Bastiaan Verhaar on 04/07/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import SwiftUI
++import LoopKitUI
++import LoopCore
++import HealthKit
++
++struct LiveActivityManagementView: View {
++    @EnvironmentObject private var displayGlucosePreference: DisplayGlucosePreference
++    @StateObject private var viewModel = LiveActivityManagementViewModel()
++    @State private var previousViewModel = LiveActivityManagementViewModel()
++    
++    @State private var isDirty = false
++   
++    var body: some View {
++        VStack {
++            List {
++                Section {
++                    Toggle(NSLocalizedString("Enabled", comment: "Title for enable live activity toggle"), isOn: $viewModel.enabled)
++                        .onChange(of: viewModel.enabled) { _ in
++                            self.isDirty = previousViewModel.enabled != viewModel.enabled
++                        }
++                    
++                    ExpandableSetting(
++                        isEditing: $viewModel.isEditingMode,
++                        leadingValueContent: {
++                            Text(NSLocalizedString("Mode", comment: "Title for mode live activity toggle"))
++                                .foregroundStyle(viewModel.isEditingMode ? .blue : .primary)
++                        },
++                        trailingValueContent: {
++                            Text(viewModel.mode.name())
++                                .foregroundStyle(viewModel.isEditingMode ? .blue : .primary)
++                        },
++                        expandedContent: {
++                            ResizeablePicker(selection: self.$viewModel.mode.animation(),
++                                             data: LiveActivityMode.all,
++                                             formatter: { $0.name() })
++                        }
++                    )
++                    .onChange(of: viewModel.mode) { _ in
++                        self.isDirty = previousViewModel.mode != viewModel.mode
++                    }
++                }
++                
++                Section {
++                    if viewModel.mode == .large {
++                        Toggle(NSLocalizedString("Add predictive line", comment: "Title for predictive line toggle"), isOn: $viewModel.addPredictiveLine)
++                            .transition(.move(edge: viewModel.mode == .large ? .top : .bottom))
++                            .onChange(of: viewModel.addPredictiveLine) { _ in
++                                self.isDirty = previousViewModel.addPredictiveLine != viewModel.addPredictiveLine
++                            }
++                    }
++                    
++                    Toggle(NSLocalizedString("Use BG coloring", comment: "Title for BG coloring"), isOn: $viewModel.useLimits)
++                        .transition(.move(edge: viewModel.mode == .large ? .top : .bottom))
++                        .onChange(of: viewModel.useLimits) { _ in
++                            self.isDirty = previousViewModel.useLimits != viewModel.useLimits
++                        }
++                    
++                    if self.displayGlucosePreference.unit == .millimolesPerLiter {
++                        TextInput(label: "Upper limit", value: $viewModel.upperLimitChartMmol)
++                            .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
++                            .onChange(of: viewModel.upperLimitChartMmol) { _ in
++                                self.isDirty = previousViewModel.upperLimitChartMmol != viewModel.upperLimitChartMmol
++                            }
++                        TextInput(label: "Lower limit", value: $viewModel.lowerLimitChartMmol)
++                            .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
++                            .onChange(of: viewModel.lowerLimitChartMmol) { _ in
++                                self.isDirty = previousViewModel.lowerLimitChartMmol != viewModel.lowerLimitChartMmol
++                            }
++                    } else {
++                        TextInput(label: "Upper limit", value: $viewModel.upperLimitChartMg)
++                            .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
++                            .onChange(of: viewModel.upperLimitChartMg) { _ in
++                                self.isDirty = previousViewModel.upperLimitChartMg != viewModel.upperLimitChartMg
++                            }
++                        TextInput(label: "Lower limit", value: $viewModel.lowerLimitChartMg)
++                            .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
++                            .onChange(of: viewModel.lowerLimitChartMg) { _ in
++                                self.isDirty = previousViewModel.lowerLimitChartMg != viewModel.lowerLimitChartMg
++                            }
++                    }
++                }
++                
++                Section {
++                    NavigationLink(
++                        destination: LiveActivityBottomRowManagerView(),
++                        label: { Text(NSLocalizedString("Bottom row configuration", comment: "Title for Bottom row configuration")) }
++                    )
++                }
++            }
++            .animation(.easeInOut, value: UUID())
++            .insetGroupedListStyle()
++            
++            Spacer()
++            Button(action: save) {
++                Text(NSLocalizedString("Save", comment: ""))
++            }
++            .buttonStyle(ActionButtonStyle())
++            .disabled(!isDirty)
++            .padding([.bottom, .horizontal])
++        }
++            .navigationBarTitle(Text(NSLocalizedString("Live activity", comment: "Live activity screen title")))
++    }
++    
++    @ViewBuilder
++    private func TextInput(label: String, value: Binding<Double>) -> some View {
++        HStack {
++            Text(NSLocalizedString(label, comment: "no comment"))
++            Spacer()
++            TextField("", value: value, format: .number)
++                .multilineTextAlignment(.trailing)
++            Text(self.displayGlucosePreference.unit.localizedShortUnitString)
++        }
++    }
++    
++    private func save() {
++        var settings = UserDefaults.standard.liveActivity ?? LiveActivitySettings()
++        settings.enabled = viewModel.enabled
++        settings.mode = viewModel.mode
++        settings.addPredictiveLine = viewModel.addPredictiveLine
++        settings.useLimits = viewModel.useLimits
++        settings.upperLimitChartMmol = viewModel.upperLimitChartMmol
++        settings.lowerLimitChartMmol = viewModel.lowerLimitChartMmol
++        settings.upperLimitChartMg = viewModel.upperLimitChartMg
++        settings.lowerLimitChartMg = viewModel.lowerLimitChartMg
++        
++        UserDefaults.standard.liveActivity = settings
++        NotificationCenter.default.post(name: .LiveActivitySettingsChanged, object: settings)
++        
++        self.isDirty = false
++        previousViewModel = LiveActivityManagementViewModel()
++    }
++}
+diff --git a/Loop/LoopCore/LiveActivitySettings.swift b/Loop/LoopCore/LiveActivitySettings.swift
+new file mode 100644
+index 00000000..d0f892f7
+--- /dev/null
++++ b/Loop/LoopCore/LiveActivitySettings.swift
+@@ -0,0 +1,159 @@
++//
++//  LiveActivitySettings.swift
++//  LoopCore
++//
++//  Created by Bastiaan Verhaar on 04/07/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++
++public enum BottomRowConfiguration: Codable {
++    case iob
++    case cob
++    case basal
++    case currentBg
++    case eventualBg
++    case deltaBg
++    case loopCircle
++    case updatedAt
++    
++    static let defaults: [BottomRowConfiguration] =  [.currentBg, .iob, .cob, .updatedAt]
++    public static let all: [BottomRowConfiguration] = [.iob, .cob, .basal, .currentBg, .eventualBg, .deltaBg, .loopCircle, .updatedAt]
++    
++    public func name() -> String {
++        switch self {
++        case .iob:
++            return NSLocalizedString("IOB", comment: "")
++        case .cob:
++            return NSLocalizedString("COB", comment: "")
++        case .basal:
++            return NSLocalizedString("Basal", comment: "")
++        case .currentBg:
++            return NSLocalizedString("Current BG", comment: "")
++        case .eventualBg:
++            return NSLocalizedString("Event", comment: "")
++        case .deltaBg:
++            return NSLocalizedString("Delta", comment: "")
++        case .loopCircle:
++            return NSLocalizedString("Loop", comment: "")
++        case .updatedAt:
++            return NSLocalizedString("Updated", comment: "")
++        }
++    }
++    
++    public func description() -> String {
++        switch self {
++        case .iob:
++            return NSLocalizedString("Active Insulin", comment: "")
++        case .cob:
++            return NSLocalizedString("Active Carbohydrates", comment: "")
++        case .basal:
++            return NSLocalizedString("Basal", comment: "")
++        case .currentBg:
++            return NSLocalizedString("Current Glucose", comment: "")
++        case .eventualBg:
++            return NSLocalizedString("Eventually", comment: "")
++        case .deltaBg:
++            return NSLocalizedString("Delta", comment: "")
++        case .loopCircle:
++            return NSLocalizedString("Loop circle", comment: "")
++        case .updatedAt:
++            return NSLocalizedString("Updated at", comment: "")
++        }
++    }
++}
++
++public enum LiveActivityMode: Codable, CustomStringConvertible {
++    case large
++    case small
++    
++    public static let all: [LiveActivityMode] = [.large, .small]
++    public var description: String {
++        NSLocalizedString("In which mode do you want to render the Live Activity", comment: "")
++    }
++    
++    public func name() -> String {
++        switch self {
++        case .large:
++            return NSLocalizedString("Large", comment: "")
++        case .small:
++            return NSLocalizedString("Small", comment: "")
++        }
++    }
++}
++
++public struct LiveActivitySettings: Codable, Equatable {
++    public var enabled: Bool
++    public var mode: LiveActivityMode
++    public var addPredictiveLine: Bool
++    public var useLimits: Bool
++    public var upperLimitChartMmol: Double
++    public var lowerLimitChartMmol: Double
++    public var upperLimitChartMg: Double
++    public var lowerLimitChartMg: Double
++    public var bottomRowConfiguration: [BottomRowConfiguration]
++    
++    private enum CodingKeys: String, CodingKey {
++        case enabled
++        case mode
++        case addPredictiveLine
++        case bottomRowConfiguration
++        case useLimits
++        case upperLimitChartMmol
++        case lowerLimitChartMmol
++        case upperLimitChartMg
++        case lowerLimitChartMg
++    }
++    
++    private static let defaultUpperLimitMmol = Double(10)
++    private static let defaultLowerLimitMmol = Double(4)
++    private static let defaultUpperLimitMg = Double(180)
++    private static let defaultLowerLimitMg = Double(72)
++    
++    public init(from decoder:Decoder) throws {
++        let values = try decoder.container(keyedBy: CodingKeys.self)
++
++        self.enabled = try values.decode(Bool.self, forKey: .enabled)
++        self.mode = try values.decodeIfPresent(LiveActivityMode.self, forKey: .mode) ?? .large
++        self.addPredictiveLine = try values.decode(Bool.self, forKey: .addPredictiveLine)
++        self.useLimits = try values.decode(Bool.self, forKey: .useLimits)
++        self.upperLimitChartMmol = try values.decode(Double?.self, forKey: .upperLimitChartMmol) ?? LiveActivitySettings.defaultUpperLimitMmol
++        self.lowerLimitChartMmol = try values.decode(Double?.self, forKey: .lowerLimitChartMmol) ?? LiveActivitySettings.defaultLowerLimitMmol
++        self.upperLimitChartMg = try values.decode(Double?.self, forKey: .upperLimitChartMg) ?? LiveActivitySettings.defaultUpperLimitMg
++        self.lowerLimitChartMg = try values.decode(Double?.self, forKey: .lowerLimitChartMg) ?? LiveActivitySettings.defaultLowerLimitMg
++        self.bottomRowConfiguration = try values.decode([BottomRowConfiguration].self, forKey: .bottomRowConfiguration)
++    }
++    
++    public init() {
++        self.enabled = true
++        self.mode = .large
++        self.addPredictiveLine = true
++        self.useLimits = true
++        self.upperLimitChartMmol = LiveActivitySettings.defaultUpperLimitMmol
++        self.lowerLimitChartMmol = LiveActivitySettings.defaultLowerLimitMmol
++        self.upperLimitChartMg = LiveActivitySettings.defaultUpperLimitMg
++        self.lowerLimitChartMg = LiveActivitySettings.defaultLowerLimitMg
++        self.bottomRowConfiguration = BottomRowConfiguration.defaults
++    }
++    
++    public static func == (lhs: LiveActivitySettings, rhs: LiveActivitySettings) -> Bool {
++        return lhs.addPredictiveLine == rhs.addPredictiveLine &&
++            lhs.mode == rhs.mode &&
++            lhs.useLimits == rhs.useLimits &&
++            lhs.lowerLimitChartMmol == rhs.lowerLimitChartMmol &&
++            lhs.upperLimitChartMmol == rhs.upperLimitChartMmol &&
++            lhs.lowerLimitChartMg == rhs.lowerLimitChartMg &&
++            lhs.upperLimitChartMg == rhs.upperLimitChartMg
++    }
++    
++    public static func != (lhs: LiveActivitySettings, rhs: LiveActivitySettings) -> Bool {
++        return lhs.addPredictiveLine != rhs.addPredictiveLine ||
++            lhs.mode != rhs.mode ||
++            lhs.useLimits != rhs.useLimits ||
++            lhs.lowerLimitChartMmol != rhs.lowerLimitChartMmol ||
++            lhs.upperLimitChartMmol != rhs.upperLimitChartMmol ||
++            lhs.lowerLimitChartMg != rhs.lowerLimitChartMg ||
++            lhs.upperLimitChartMg != rhs.upperLimitChartMg
++    }
++}
+diff --git a/Loop/LoopCore/NSUserDefaults.swift b/Loop/LoopCore/NSUserDefaults.swift
+index 93fa7e17..dacf2ecd 100644
+--- a/Loop/LoopCore/NSUserDefaults.swift
++++ b/Loop/LoopCore/NSUserDefaults.swift
+@@ -23,6 +23,7 @@ extension UserDefaults {
+         case allowSimulators = "com.loopkit.Loop.allowSimulators"
+         case LastMissedMealNotification = "com.loopkit.Loop.lastMissedMealNotification"
+         case userRequestedLoopReset = "com.loopkit.Loop.userRequestedLoopReset"
++        case liveActivity = "com.loopkit.Loop.liveActivity"
+     }
+ 
+     public static let appGroup = UserDefaults(suiteName: Bundle.main.appGroupSuiteName)
+@@ -165,6 +166,29 @@ extension UserDefaults {
+             setValue(newValue, forKey: Key.userRequestedLoopReset.rawValue)
+         }
+     }
++    
++    public var liveActivity: LiveActivitySettings? {
++        get {
++            let decoder = JSONDecoder()
++            guard let data = object(forKey: Key.liveActivity.rawValue) as? Data else {
++                return nil
++            }
++            return try? decoder.decode(LiveActivitySettings.self, from: data)
++        }
++        set {
++            do {
++                if let newValue = newValue {
++                    let encoder = JSONEncoder()
++                    let data = try encoder.encode(newValue)
++                    set(data, forKey: Key.liveActivity.rawValue)
++                } else {
++                    set(nil, forKey: Key.liveActivity.rawValue)
++                }
++            } catch {
++                assertionFailure("Unable to encode MissedMealNotification")
++            }
++        }
++    }
+ 
+     public func removeLegacyLoopSettings() {
+         removeObject(forKey: "com.loudnate.Naterade.BasalRateSchedule")

--- a/live_activity/dev377_live_activity_negative_insulin.patch
+++ b/live_activity/dev377_live_activity_negative_insulin.patch
@@ -1,0 +1,2374 @@
+Submodule Loop 1ea220f...3645d8c:
+diff --git a/Loop/Loop Widget Extension/Bootstrap/Bootstrap.swift b/Loop/Loop Widget Extension/Bootstrap/Bootstrap.swift
+new file mode 100644
+index 00000000..00823471
+--- /dev/null
++++ b/Loop/Loop Widget Extension/Bootstrap/Bootstrap.swift	
+@@ -0,0 +1,11 @@
++//
++//  Bootstrap.swift
++//  Loop Widget Extension
++//
++//  Created by Bastiaan Verhaar on 25/06/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++
++class Bootstrap{}
+diff --git a/Loop/Loop Widget Extension/Helpers/LocalizedString.swift b/Loop/Loop Widget Extension/Helpers/LocalizedString.swift
+new file mode 100644
+index 00000000..15818175
+--- /dev/null
++++ b/Loop/Loop Widget Extension/Helpers/LocalizedString.swift	
+@@ -0,0 +1,21 @@
++//
++//  LocalizedString.swift
++//  Loop Widget Extension
++//
++//  Created by Bastiaan Verhaar on 25/06/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++
++private class FrameworkBundle {
++    static let main = Bundle(for: Bootstrap.self)
++}
++
++func LocalizedString(_ key: String, tableName: String? = nil, value: String? = nil, comment: String) -> String {
++    if let value = value {
++        return NSLocalizedString(key, tableName: tableName, bundle: FrameworkBundle.main, value: value, comment: comment)
++    } else {
++        return NSLocalizedString(key, tableName: tableName, bundle: FrameworkBundle.main, comment: comment)
++    }
++}
+diff --git a/Loop/Loop Widget Extension/Live Activity/BasalViewActivity.swift b/Loop/Loop Widget Extension/Live Activity/BasalViewActivity.swift
+new file mode 100644
+index 00000000..915335c5
+--- /dev/null
++++ b/Loop/Loop Widget Extension/Live Activity/BasalViewActivity.swift	
+@@ -0,0 +1,46 @@
++//
++//  BasalView.swift
++//  Loop
++//
++//  Created by Noah Brauner on 8/15/22.
++//  Copyright © 2022 LoopKit Authors. All rights reserved.
++//
++
++import SwiftUI
++
++struct BasalViewActivity: View {
++    let percent: Double
++    let rate: Double
++    
++    var body: some View {        
++        VStack(spacing: 1) {
++            BasalRateView(percent: percent)
++                .overlay(
++                    BasalRateView(percent: percent)
++                        .stroke(Color("insulin"), lineWidth: 2)
++                )
++                .foregroundColor(Color("insulin").opacity(0.5))
++                .frame(width: 44, height: 22)
++
++            if let rateString = decimalFormatter.string(from: NSNumber(value: rate)) {
++                Text("\(rateString)U")
++                    .font(.subheadline)
++            }
++            else {
++                Text("-U")
++                    .font(.subheadline)
++            }
++        }
++    }
++    
++    private let decimalFormatter: NumberFormatter = {
++        let formatter = NumberFormatter()
++        formatter.numberStyle = .decimal
++        formatter.minimumFractionDigits = 1
++        formatter.minimumIntegerDigits = 1
++        formatter.positiveFormat = "+0.0##"
++        formatter.negativeFormat = "-0.0##"
++
++        return formatter
++    }()
++}
+diff --git a/Loop/Loop Widget Extension/Live Activity/ChartView.swift b/Loop/Loop Widget Extension/Live Activity/ChartView.swift
+new file mode 100644
+index 00000000..b65e02c9
+--- /dev/null
++++ b/Loop/Loop Widget Extension/Live Activity/ChartView.swift	
+@@ -0,0 +1,159 @@
++//
++//  ChartValues.swift
++//  Loop Widget Extension
++//
++//  Created by Bastiaan Verhaar on 25/06/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import SwiftUI
++import Charts
++
++struct ChartView: View {
++    private let glucoseSampleData: [ChartValues]
++    private let predicatedData: [ChartValues]
++    private let glucoseRanges: [GlucoseRangeValue]
++    private let preset: Preset?
++    private let yAxisMarks: [Double]
++    
++    init(glucoseSamples: [GlucoseSampleAttributes], predicatedGlucose: [Double], predicatedStartDate: Date?, predicatedInterval: TimeInterval?, useLimits: Bool, lowerLimit: Double, upperLimit: Double, glucoseRanges: [GlucoseRangeValue], preset: Preset?, yAxisMarks: [Double]) {
++        self.glucoseSampleData = ChartValues.convert(data: glucoseSamples, useLimits: useLimits, lowerLimit: lowerLimit, upperLimit: upperLimit)
++        self.predicatedData = ChartValues.convert(
++            data: predicatedGlucose,
++            startDate: predicatedStartDate ?? Date.now,
++            interval: predicatedInterval ?? .minutes(5),
++            useLimits: useLimits,
++            lowerLimit: lowerLimit,
++            upperLimit: upperLimit
++        )
++        self.preset = preset
++        self.glucoseRanges = glucoseRanges
++        self.yAxisMarks = yAxisMarks
++    }
++    
++    init(glucoseSamples: [GlucoseSampleAttributes], useLimits: Bool, lowerLimit: Double, upperLimit: Double, glucoseRanges: [GlucoseRangeValue], preset: Preset?, yAxisMarks: [Double]) {
++        self.glucoseSampleData = ChartValues.convert(data: glucoseSamples, useLimits: useLimits, lowerLimit: lowerLimit, upperLimit: upperLimit)
++        self.predicatedData = []
++        self.preset = preset
++        self.glucoseRanges = glucoseRanges
++        self.yAxisMarks = yAxisMarks
++    }
++    
++    var body: some View {
++        ZStack(alignment: Alignment(horizontal: .trailing, vertical: .top)){
++            Chart {
++                if let preset = self.preset, predicatedData.count > 0, preset.endDate > Date.now.addingTimeInterval(.hours(-6)) {
++                    RectangleMark(
++                        xStart: .value("Start", preset.startDate),
++                        xEnd: .value("End", preset.endDate),
++                        yStart: .value("Preset override", preset.minValue),
++                        yEnd: .value("Preset override", preset.maxValue)
++                    )
++                    .foregroundStyle(.primary)
++                    .opacity(0.6)
++                }
++                
++                ForEach(glucoseRanges) { item in
++                    RectangleMark(
++                        xStart: .value("Start", item.startDate),
++                        xEnd: .value("End", item.endDate),
++                        yStart: .value("Glucose range", item.minValue),
++                        yEnd: .value("Glucose range", item.maxValue)
++                    )
++                    .foregroundStyle(.primary)
++                    .opacity(0.3)
++                }
++                
++                ForEach(glucoseSampleData) { item in
++                    PointMark (x: .value("Date", item.x),
++                               y: .value("Glucose level", item.y)
++                    )
++                    .symbolSize(20)
++                    .foregroundStyle(by: .value("Color", item.color))
++                }
++                
++                ForEach(predicatedData) { item in
++                    LineMark (x: .value("Date", item.x),
++                              y: .value("Glucose level", item.y)
++                    )
++                    .lineStyle(StrokeStyle(lineWidth: 3, dash: [2, 3]))
++                }
++            }
++            .chartForegroundStyleScale([
++                "Good": .green,
++                "High": .orange,
++                "Low": .red,
++                "Default": .blue
++            ])
++            .chartPlotStyle { plotContent in
++                plotContent.background(.cyan.opacity(0.15))
++            }
++            .chartLegend(.hidden)
++            .chartYScale(domain: [yAxisMarks.first ?? 0, yAxisMarks.last ?? 0])
++            .chartYAxis {
++                AxisMarks(values: yAxisMarks)
++            }
++            .chartYAxis {
++                AxisMarks(position: .leading) { _ in
++                    AxisValueLabel().foregroundStyle(Color.primary)
++                    AxisGridLine(stroke: .init(lineWidth: 0.1, dash: [2, 3]))
++                        .foregroundStyle(Color.primary)
++                }
++            }
++            .chartXAxis {
++                AxisMarks(position: .automatic, values: .stride(by: .hour)) { _ in
++                    AxisValueLabel(format: .dateTime.hour(.twoDigits(amPM: .narrow)), anchor: .top)
++                        .foregroundStyle(Color.primary)
++                    AxisGridLine(stroke: .init(lineWidth: 0.1, dash: [2, 3]))
++                        .foregroundStyle(Color.primary)
++                }
++            }
++            
++            if let preset = self.preset, preset.endDate > Date.now {
++                Text(preset.title)
++                    .font(.footnote)
++                    .padding(.trailing, 5)
++                    .padding(.top, 2)
++            }
++        }
++    }
++}
++
++struct ChartValues: Identifiable {
++    public let id: UUID
++    public let x: Date
++    public let y: Double
++    public let color: String
++    
++    init(x: Date, y: Double, color: String) {
++        self.id = UUID()
++        self.x = x
++        self.y = y
++        self.color = color
++    }
++    
++    static func convert(data: [Double], startDate: Date, interval: TimeInterval, useLimits: Bool, lowerLimit: Double, upperLimit: Double) -> [ChartValues] {
++        let twoHours = Date.now.addingTimeInterval(.hours(4))
++        
++        return data.enumerated().filter { (index, item) in
++            return startDate.addingTimeInterval(interval * Double(index)) < twoHours
++        }.map { (index, item) in
++            return ChartValues(
++                x: startDate.addingTimeInterval(interval * Double(index)),
++                y: item,
++                color: !useLimits ? "Default" : item < lowerLimit ? "Low" : item > upperLimit ? "High" : "Good"
++            )
++        }
++    }
++    
++    static func convert(data: [GlucoseSampleAttributes], useLimits: Bool, lowerLimit: Double, upperLimit: Double) -> [ChartValues] {
++        return data.map { item in
++            return ChartValues(
++                x: item.x,
++                y: item.y,
++                color: !useLimits ? "Default" : item.y < lowerLimit ? "Low" : item.y > upperLimit ? "High" : "Good"
++            )
++        }
++    }
++}
+diff --git a/Loop/Loop Widget Extension/Live Activity/GlucoseLiveActivityConfiguration.swift b/Loop/Loop Widget Extension/Live Activity/GlucoseLiveActivityConfiguration.swift
+new file mode 100644
+index 00000000..4d5ed5ef
+--- /dev/null
++++ b/Loop/Loop Widget Extension/Live Activity/GlucoseLiveActivityConfiguration.swift	
+@@ -0,0 +1,298 @@
++//
++//  LiveActivityConfiguration.swift
++//  Loop Widget Extension
++//
++//  Created by Bastiaan Verhaar on 23/06/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import ActivityKit
++import LoopKit
++import SwiftUI
++import LoopCore
++import WidgetKit
++import Charts
++import HealthKit
++
++@available(iOS 16.2, *)
++struct GlucoseLiveActivityConfiguration: Widget {
++    private let timeFormatter: DateFormatter = {
++        let dateFormatter = DateFormatter()
++        dateFormatter.dateStyle = .none
++        dateFormatter.timeStyle = .short
++        
++        return dateFormatter
++    }()
++    
++    var body: some WidgetConfiguration {
++        ActivityConfiguration(for: GlucoseActivityAttributes.self) { context in
++            // Create the presentation that appears on the Lock Screen and as a
++            // banner on the Home Screen of devices that don't support the Dynamic Island.
++            ZStack {
++                VStack {
++                    if context.attributes.mode == .large {
++                        HStack(spacing: 15) {
++                            loopIcon(context)
++                            if context.attributes.addPredictiveLine {
++                                ChartView(
++                                    glucoseSamples: context.state.glucoseSamples,
++                                    predicatedGlucose: context.state.predicatedGlucose,
++                                    predicatedStartDate: context.state.predicatedStartDate,
++                                    predicatedInterval: context.state.predicatedInterval,
++                                    useLimits: context.attributes.useLimits,
++                                    lowerLimit: context.state.isMmol ? context.attributes.lowerLimitChartMmol : context.attributes.lowerLimitChartMg,
++                                    upperLimit: context.state.isMmol ? context.attributes.upperLimitChartMmol : context.attributes.upperLimitChartMg,
++                                    glucoseRanges: context.state.glucoseRanges,
++                                    preset: context.state.preset,
++                                    yAxisMarks: context.state.yAxisMarks
++                                )
++                                .frame(height: 85)
++                            } else {
++                                ChartView(
++                                    glucoseSamples: context.state.glucoseSamples,
++                                    useLimits: context.attributes.useLimits,
++                                    lowerLimit: context.state.isMmol ? context.attributes.lowerLimitChartMmol : context.attributes.lowerLimitChartMg,
++                                    upperLimit: context.state.isMmol ? context.attributes.upperLimitChartMmol : context.attributes.upperLimitChartMg,
++                                    glucoseRanges: context.state.glucoseRanges,
++                                    preset: context.state.preset,
++                                    yAxisMarks: context.state.yAxisMarks
++                                )
++                                .frame(height: 85)
++                            }
++                        }
++                    }
++                    
++                    HStack {
++                        bottomSpacer(border: false)
++                        
++                        let endIndex = context.state.bottomRow.endIndex - 1
++                        ForEach(Array(context.state.bottomRow.enumerated()), id: \.element) { (index, item) in
++                            switch (item.type) {
++                            case .generic:
++                                bottomItemGeneric(
++                                    title: item.label,
++                                    value: item.value,
++                                    unit: LocalizedString(item.unit, comment: "No comment")
++                                )
++                                
++                            case .basal:
++                                BasalViewActivity(percent: item.percentage, rate: item.rate)
++                                
++                            case .currentBg:
++                                bottomItemCurrentBG(
++                                    value: item.value,
++                                    trend: item.trend,
++                                    context: context
++                                )
++                                
++                            case .loopCircle:
++                                bottomItemLoopCircle(context: context)
++                            }
++                            
++                            if index != endIndex {
++                                bottomSpacer(border: true)
++                            }
++                        }
++                        
++                        bottomSpacer(border: false)
++                    }
++                }
++                if context.state.ended {
++                    VStack {
++                        Spacer()
++                        HStack {
++                            Spacer()
++                            Text(NSLocalizedString("Open the app to update the widget", comment: "No comment"))
++                            Spacer()
++                        }
++                        Spacer()
++                    }
++                    .background(.ultraThinMaterial.opacity(0.8))
++                    .padding(.all, -15)
++                }
++            }
++                .privacySensitive()
++                .padding(.all, 15)
++                .background(BackgroundStyle.background.opacity(0.4))
++                .activityBackgroundTint(Color.clear)
++        } dynamicIsland: { context in
++            let glucoseFormatter = NumberFormatter.glucoseFormatter(for: context.state.isMmol ? HKUnit.millimolesPerLiter : HKUnit.milligramsPerDeciliter)
++            
++            return DynamicIsland {
++                DynamicIslandExpandedRegion(.leading) {
++                    HStack(alignment: .center) {
++                        loopIcon(context)
++                            .frame(width: 40, height: 40, alignment: .trailing)
++                        Spacer()
++                        Text("\(glucoseFormatter.string(from: context.state.currentGlucose) ?? "??")\(getArrowImage(context.state.trendType))")
++                            .foregroundStyle(getGlucoseColor(context.state.currentGlucose, context: context))
++                            .font(.headline)
++                            .fontWeight(.heavy)
++                    }
++                }
++                DynamicIslandExpandedRegion(.trailing) {
++                    HStack{
++                        Text(context.state.delta)
++                            .foregroundStyle(Color(white: 0.9))
++                            .font(.headline)
++                        Text(context.state.isMmol ? HKUnit.millimolesPerLiter.localizedShortUnitString : HKUnit.milligramsPerDeciliter.localizedShortUnitString)
++                            .foregroundStyle(Color(white: 0.7))
++                            .font(.subheadline)
++                    }
++                }
++                DynamicIslandExpandedRegion(.bottom) {
++                    if context.attributes.addPredictiveLine {
++                        ChartView(
++                            glucoseSamples: context.state.glucoseSamples,
++                            predicatedGlucose: context.state.predicatedGlucose,
++                            predicatedStartDate: context.state.predicatedStartDate,
++                            predicatedInterval: context.state.predicatedInterval,
++                            useLimits: context.attributes.useLimits,
++                            lowerLimit: context.state.isMmol ? context.attributes.lowerLimitChartMmol : context.attributes.lowerLimitChartMg,
++                            upperLimit: context.state.isMmol ? context.attributes.upperLimitChartMmol : context.attributes.upperLimitChartMg,
++                            glucoseRanges: context.state.glucoseRanges,
++                            preset: context.state.preset,
++                            yAxisMarks: context.state.yAxisMarks
++                        )
++                            .frame(height: 75)
++                    } else {
++                        ChartView(
++                            glucoseSamples: context.state.glucoseSamples,
++                            useLimits: context.attributes.useLimits,
++                            lowerLimit: context.state.isMmol ? context.attributes.lowerLimitChartMmol : context.attributes.lowerLimitChartMg,
++                            upperLimit: context.state.isMmol ? context.attributes.upperLimitChartMmol : context.attributes.upperLimitChartMg,
++                            glucoseRanges: context.state.glucoseRanges,
++                            preset: context.state.preset,
++                            yAxisMarks: context.state.yAxisMarks
++                        )
++                            .frame(height: 75)
++                    }
++                }
++            } compactLeading: {
++                Text("\(glucoseFormatter.string(from: context.state.currentGlucose) ?? "??")\(getArrowImage(context.state.trendType))")
++                    .foregroundStyle(getGlucoseColor(context.state.currentGlucose, context: context))
++                    .minimumScaleFactor(0.1)
++            } compactTrailing: {
++                Text(context.state.delta)
++                    .foregroundStyle(Color(white: 0.9))
++                    .minimumScaleFactor(0.1)
++            } minimal: {
++                Text(glucoseFormatter.string(from: context.state.currentGlucose) ?? "??")
++                    .foregroundStyle(getGlucoseColor(context.state.currentGlucose, context: context))
++                    .minimumScaleFactor(0.1)
++            }
++        }
++    }
++    
++    @ViewBuilder
++    private func loopIcon(_ context: ActivityViewContext<GlucoseActivityAttributes>) -> some View {
++        Circle()
++            .trim(from: context.state.isCloseLoop ? 0 : 0.2, to: 1)
++            .stroke(getLoopColor(context.state.lastCompleted), lineWidth: 8)
++            .rotationEffect(Angle(degrees: -126))
++            .frame(width: 36, height: 36)
++    }
++    
++    @ViewBuilder
++    private func bottomItemGeneric(title: String, value: String, unit: String) -> some View {
++        VStack(alignment: .center) {
++            Text("\(value)\(unit)")
++                .font(.headline)
++                .foregroundStyle(.primary)
++                .fontWeight(.heavy)
++                .font(Font.body.leading(.tight))
++            Text(title)
++                .font(.subheadline)
++        }
++    }
++    
++    @ViewBuilder
++    private func bottomItemCurrentBG(value: String, trend: GlucoseTrend?, context: ActivityViewContext<GlucoseActivityAttributes>) -> some View {
++        VStack(alignment: .center) {
++            HStack {
++                Text(value + getArrowImage(trend))
++                    .font(.title)
++                    .foregroundStyle(!context.attributes.useLimits ? .primary : getGlucoseColor(context.state.currentGlucose, context: context))
++                    .fontWeight(.heavy)
++                    .font(Font.body.leading(.tight))
++            }
++        }
++    }
++    
++    @ViewBuilder
++    private func bottomItemLoopCircle(context: ActivityViewContext<GlucoseActivityAttributes>) -> some View {
++        VStack(alignment: .center) {
++            loopIcon(context)
++        }
++    }
++    
++    @ViewBuilder
++    private func bottomSpacer(border: Bool) -> some View {
++        Spacer()
++        if (border) {
++            Divider()
++                .background(.secondary)
++            Spacer()
++        }
++        
++    }
++    
++    private func getArrowImage(_ trendType: GlucoseTrend?) -> String {
++        switch trendType {
++        case .upUpUp:
++            return "\u{2191}\u{2191}" // ↑↑
++        case .upUp:
++            return "\u{2191}" // ↑
++        case .up:
++            return "\u{2197}" // ↗
++        case .flat:
++            return "\u{2192}" // →
++        case .down:
++            return "\u{2198}" // ↘
++        case .downDown:
++            return "\u{2193}" // ↓
++        case .downDownDown:
++            return "\u{2193}\u{2193}" // ↓↓
++        case .none:
++            return ""
++        }
++    }
++    
++    private func getLoopColor(_ age: Date?) -> Color {
++        var freshness: LoopCompletionFreshness = .stale
++        if let age = age {
++            freshness = LoopCompletionFreshness(age: abs(min(0, age.timeIntervalSinceNow)))
++        }
++        
++        switch freshness {
++        case .fresh:
++            return Color("fresh")
++        case .aging:
++            return Color("warning")
++        case .stale:
++            return .red
++        }
++    }
++    
++    private func getGlucoseColor(_ value: Double, context: ActivityViewContext<GlucoseActivityAttributes>) -> Color {
++        guard context.attributes.useLimits else {
++            return .primary
++        }
++        
++        if
++            context.state.isMmol && value < context.attributes.lowerLimitChartMmol ||
++            !context.state.isMmol && value < context.attributes.lowerLimitChartMg
++        {
++            return .red
++        }
++        
++        if
++            context.state.isMmol && value > context.attributes.upperLimitChartMmol ||
++            !context.state.isMmol && value > context.attributes.upperLimitChartMg
++        {
++            return .orange
++        }
++        
++        return .green
++    }
++}
+diff --git a/Loop/Loop Widget Extension/LoopWidgets.swift b/Loop/Loop Widget Extension/LoopWidgets.swift
+index 26f92edb..684bf073 100644
+--- a/Loop/Loop Widget Extension/LoopWidgets.swift	
++++ b/Loop/Loop Widget Extension/LoopWidgets.swift	
+@@ -14,5 +14,6 @@ struct LoopWidgets: WidgetBundle {
+     @WidgetBundleBuilder
+     var body: some Widget {
+         SystemStatusWidget()
++        GlucoseLiveActivityConfiguration()
+     }
+ }
+diff --git a/Loop/Loop.xcodeproj/project.pbxproj b/Loop/Loop.xcodeproj/project.pbxproj
+index 4ff92544..7e00af68 100644
+--- a/Loop/Loop.xcodeproj/project.pbxproj
++++ b/Loop/Loop.xcodeproj/project.pbxproj
+@@ -392,6 +392,21 @@
+ 		B4E96D5D248A82A2002DABAD /* StatusBarHUDView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B4E96D5C248A82A2002DABAD /* StatusBarHUDView.xib */; };
+ 		B4F3D25124AF890C0095CE44 /* BluetoothStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3D25024AF890C0095CE44 /* BluetoothStateManager.swift */; };
+ 		B4FEEF7D24B8A71F00A8DF9B /* DeviceDataManager+DeviceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FEEF7C24B8A71F00A8DF9B /* DeviceDataManager+DeviceStatus.swift */; };
++		B82181F62C93628300478A91 /* LiveActivityManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82181F52C93628300478A91 /* LiveActivityManagementViewModel.swift */; };
++		B82182002C93716A00478A91 /* ChartAxisGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82181F92C936AD600478A91 /* ChartAxisGenerator.swift */; };
++		B851FFC52C37221800D738C1 /* LiveActivityManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B851FFC42C37221800D738C1 /* LiveActivityManagementView.swift */; };
++		B851FFCA2C3731DE00D738C1 /* LiveActivitySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B851FFC62C37271E00D738C1 /* LiveActivitySettings.swift */; };
++		B851FFCB2C3731DE00D738C1 /* LiveActivitySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B851FFC62C37271E00D738C1 /* LiveActivitySettings.swift */; };
++		B87539C92C2B06CE0085A975 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87539C82C2B06CE0085A975 /* LocalizedString.swift */; };
++		B87539CB2C2B08430085A975 /* Bootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87539CA2C2B08430085A975 /* Bootstrap.swift */; };
++		B87539CD2C2B46950085A975 /* ChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87539CC2C2B46950085A975 /* ChartView.swift */; };
++		B87539CF2C2DCB770085A975 /* BasalViewActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87539CE2C2DCB770085A975 /* BasalViewActivity.swift */; };
++		B87D411D2C28A69600120877 /* GlucoseLiveActivityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87D411C2C28A69600120877 /* GlucoseLiveActivityConfiguration.swift */; };
++		B87D411F2C28A85F00120877 /* ActivityKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B87D411E2C28A85F00120877 /* ActivityKit.framework */; };
++		B8A937B82C29BA5900E38645 /* GlucoseActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A937B72C29BA5900E38645 /* GlucoseActivityManager.swift */; };
++		B8A937C32C29C3B400E38645 /* GlucoseActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A937C02C29C29300E38645 /* GlucoseActivityAttributes.swift */; };
++		B8A937C42C29C43B00E38645 /* GlucoseActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A937C02C29C29300E38645 /* GlucoseActivityAttributes.swift */; };
++		B8FD0B522C39CA3E003FB72B /* LiveActivityBottomRowManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FD0B512C39CA3E003FB72B /* LiveActivityBottomRowManagerView.swift */; };
+ 		B66D1F212E6A5D6500471149 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B66D1F202E6A5D6500471149 /* InfoPlist.xcstrings */; };
+ 		B66D1F232E6A5D6500471149 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B66D1F222E6A5D6500471149 /* InfoPlist.xcstrings */; };
+ 		B66D1F252E6A5D6500471149 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B66D1F242E6A5D6500471149 /* InfoPlist.xcstrings */; };
+@@ -730,6 +745,16 @@
+ 			name = "Embed App Extensions";
+ 			runOnlyForDeploymentPostprocessing = 0;
+ 		};
++		B82181FF2C9370F800478A91 /* Embed Frameworks */ = {
++			isa = PBXCopyFilesBuildPhase;
++			buildActionMask = 2147483647;
++			dstPath = "";
++			dstSubfolderSpec = 10;
++			files = (
++			);
++			name = "Embed Frameworks";
++			runOnlyForDeploymentPostprocessing = 0;
++		};
+ 		C1E3DC4828595FAA00CA19FF /* Embed Frameworks */ = {
+ 			isa = PBXCopyFilesBuildPhase;
+ 			buildActionMask = 2147483647;
+@@ -1181,6 +1206,19 @@
+ 		B4E96D5C248A82A2002DABAD /* StatusBarHUDView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatusBarHUDView.xib; sourceTree = "<group>"; };
+ 		B4F3D25024AF890C0095CE44 /* BluetoothStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothStateManager.swift; sourceTree = "<group>"; };
+ 		B4FEEF7C24B8A71F00A8DF9B /* DeviceDataManager+DeviceStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeviceDataManager+DeviceStatus.swift"; sourceTree = "<group>"; };
++		B82181F52C93628300478A91 /* LiveActivityManagementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManagementViewModel.swift; sourceTree = "<group>"; };
++		B82181F92C936AD600478A91 /* ChartAxisGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartAxisGenerator.swift; sourceTree = "<group>"; };
++		B851FFC42C37221800D738C1 /* LiveActivityManagementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManagementView.swift; sourceTree = "<group>"; };
++		B851FFC62C37271E00D738C1 /* LiveActivitySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivitySettings.swift; sourceTree = "<group>"; };
++		B87539C82C2B06CE0085A975 /* LocalizedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedString.swift; sourceTree = "<group>"; };
++		B87539CA2C2B08430085A975 /* Bootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bootstrap.swift; sourceTree = "<group>"; };
++		B87539CC2C2B46950085A975 /* ChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartView.swift; sourceTree = "<group>"; };
++		B87539CE2C2DCB770085A975 /* BasalViewActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasalViewActivity.swift; sourceTree = "<group>"; };
++		B87D411C2C28A69600120877 /* GlucoseLiveActivityConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseLiveActivityConfiguration.swift; sourceTree = "<group>"; };
++		B87D411E2C28A85F00120877 /* ActivityKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ActivityKit.framework; path = System/Library/Frameworks/ActivityKit.framework; sourceTree = SDKROOT; };
++		B8A937B72C29BA5900E38645 /* GlucoseActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseActivityManager.swift; sourceTree = "<group>"; };
++		B8A937C02C29C29300E38645 /* GlucoseActivityAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlucoseActivityAttributes.swift; sourceTree = "<group>"; };
++		B8FD0B512C39CA3E003FB72B /* LiveActivityBottomRowManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityBottomRowManagerView.swift; sourceTree = "<group>"; };
+ 		B66D1F202E6A5D6500471149 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+ 		B66D1F222E6A5D6500471149 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+ 		B66D1F242E6A5D6500471149 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+@@ -1729,6 +1767,7 @@
+ 				1419606928D9554E00BA86E0 /* LoopKitUI.framework in Frameworks */,
+ 				1419606A28D955BC00BA86E0 /* MockKitUI.framework in Frameworks */,
+ 				1481F9BB28DA26F4004C5AEB /* LoopUI.framework in Frameworks */,
++				B87D411F2C28A85F00120877 /* ActivityKit.framework in Frameworks */,
+ 				1419606428D9550400BA86E0 /* LoopKitUI.framework in Frameworks */,
+ 			);
+ 			runOnlyForDeploymentPostprocessing = 0;
+@@ -1838,6 +1877,7 @@
+ 				84AA81D12A4A2778000B658B /* Components */,
+ 				84AA81D92A4A2966000B658B /* Helpers */,
+ 				84AA81DE2A4A2B3D000B658B /* Timeline */,
++				B87D41192C28A61900120877 /* Live Activity */,
+ 				84AA81DF2A4A2B7A000B658B /* Widgets */,
+ 				84AA81D22A4A27A3000B658B /* LoopWidgets.swift */,
+ 			);
+@@ -2165,6 +2205,7 @@
+ 				43DE92581C5479E4001FFDE1 /* PotentialCarbEntryUserInfo.swift */,
+ 				43C05CB721EBEA54006FB252 /* HKUnit.swift */,
+ 				434FF1E91CF26C29000DB779 /* IdentifiableClass.swift */,
++				E9C00EEF24C620EF00628F35 /* LoopSettings.swift */,
+ 				C19E96DD23D2733F003F79B0 /* LoopCompletionFreshness.swift */,
+ 				430B29892041F54A00BA9F93 /* NSUserDefaults.swift */,
+ 				431E73471FF95A900069B5F7 /* PersistenceController.swift */,
+@@ -2172,10 +2213,10 @@
+ 				43D9FFD121EAE05D00AF44BF /* LoopCore.h */,
+ 				43D9FFD221EAE05D00AF44BF /* Info.plist */,
+ 				B66D1F3A2E6A5D6600471149 /* Localizable.xcstrings */,
+-				E9C00EEF24C620EF00628F35 /* LoopSettings.swift */,
+ 				C16575742539FD60004AE16E /* LoopCoreConstants.swift */,
+ 				E9B3551B292844010076AB04 /* MissedMealNotification.swift */,
+ 				C1D0B62F2986D4D90098D215 /* LocalizedString.swift */,
++				B851FFC62C37271E00D738C1 /* LiveActivitySettings.swift */,
+ 			);
+ 			path = LoopCore;
+ 			sourceTree = "<group>";
+@@ -2278,6 +2319,8 @@
+ 				C1AF062229426300002C1B19 /* ManualGlucoseEntryRow.swift */,
+ 				DDC389FD2A2C4C830066E2E8 /* GlucoseBasedApplicationFactorSelectionView.swift */,
+ 				DD3DBD282A33AFE9000F8B5B /* IntegralRetrospectiveCorrectionSelectionView.swift */,
++				B851FFC42C37221800D738C1 /* LiveActivityManagementView.swift */,
++				B8FD0B512C39CA3E003FB72B /* LiveActivityBottomRowManagerView.swift */,
+ 				120490CA2CBFB25A006BDF0A /* NegativeInsulinDamperSelectionView.swift */,
+ 			);
+ 			path = Views;
+@@ -2318,6 +2361,7 @@
+ 				1DA6499D2441266400F61E75 /* Alerts */,
+ 				E95D37FF24EADE68005E2F50 /* Store Protocols */,
+ 				E9B355232935906B0076AB04 /* Missed Meal Detection */,
++				B8A937C52C29C44600E38645 /* Live Activity */,
+ 				C1F2075B26D6F9B0007AB7EB /* AppExpirationAlerter.swift */,
+ 				A96DAC2B2838F31200D94E38 /* SharedLogging.swift */,
+ 				7E69CFFB2A16A77E00203CBD /* ResetLoopManager.swift */,
+@@ -2528,6 +2572,7 @@
+ 				B66D1F2E2E6A5D6600471149 /* InfoPlist.xcstrings */,
+ 				14B1736D28AEDA63006CCD7C /* LoopWidgetExtension.entitlements */,
+ 				14B1736628AED9EE006CCD7C /* Info.plist */,
++				B87539CA2C2B08430085A975 /* Bootstrap.swift */,
+ 			);
+ 			path = Bootstrap;
+ 			sourceTree = "<group>";
+@@ -2538,6 +2583,7 @@
+ 				84AA81DA2A4A2973000B658B /* Date.swift */,
+ 				84AA81D52A4A28AF000B658B /* WidgetBackground.swift */,
+ 				84D2879E2AC756C8007ED283 /* ContentMargin.swift */,
++				B87539C82C2B06CE0085A975 /* LocalizedString.swift */,
+ 			);
+ 			path = Helpers;
+ 			sourceTree = "<group>";
+@@ -2631,6 +2677,7 @@
+ 				1D49795724E7289700948F05 /* ServicesViewModel.swift */,
+ 				C174233B259BEB0F00399C9D /* ManualEntryDoseViewModel.swift */,
+ 				1DB619AB270BAD3D006C9D07 /* VersionUpdateViewModel.swift */,
++				B82181F52C93628300478A91 /* LiveActivityManagementViewModel.swift */,
+ 			);
+ 			path = "View Models";
+ 			sourceTree = "<group>";
+@@ -2666,6 +2713,7 @@
+ 		968DCD53F724DE56FFE51920 /* Frameworks */ = {
+ 			isa = PBXGroup;
+ 			children = (
++				B87D411E2C28A85F00120877 /* ActivityKit.framework */,
+ 				C159C82E286787EF00A86EC0 /* LoopKit.framework */,
+ 				C159C8212867859800A86EC0 /* MockKitUI.framework */,
+ 				C159C8192867857000A86EC0 /* LoopKitUI.framework */,
+@@ -2763,6 +2811,26 @@
+ 			path = LoopCore;
+ 			sourceTree = "<group>";
+ 		};
++		B87D41192C28A61900120877 /* Live Activity */ = {
++			isa = PBXGroup;
++			children = (
++				B87D411C2C28A69600120877 /* GlucoseLiveActivityConfiguration.swift */,
++				B87539CC2C2B46950085A975 /* ChartView.swift */,
++				B87539CE2C2DCB770085A975 /* BasalViewActivity.swift */,
++			);
++			path = "Live Activity";
++			sourceTree = "<group>";
++		};
++		B8A937C52C29C44600E38645 /* Live Activity */ = {
++			isa = PBXGroup;
++			children = (
++				B8A937B72C29BA5900E38645 /* GlucoseActivityManager.swift */,
++				B8A937C02C29C29300E38645 /* GlucoseActivityAttributes.swift */,
++				B82181F92C936AD600478A91 /* ChartAxisGenerator.swift */,
++			);
++			path = "Live Activity";
++			sourceTree = "<group>";
++		};
+ 		C13072B82A76AF0A009A7C58 /* live_capture */ = {
+ 			isa = PBXGroup;
+ 			children = (
+@@ -2985,6 +3053,7 @@
+ 				14B1735828AED9EC006CCD7C /* Sources */,
+ 				14B1735928AED9EC006CCD7C /* Frameworks */,
+ 				14B1735A28AED9EC006CCD7C /* Resources */,
++				B82181FF2C9370F800478A91 /* Embed Frameworks */,
+ 			);
+ 			buildRules = (
+ 			);
+@@ -2992,6 +3061,8 @@
+ 				1481F9BE28DA26F4004C5AEB /* PBXTargetDependency */,
+ 			);
+ 			name = "Loop Widget Extension";
++			packageProductDependencies = (
++			);
+ 			productName = SmallStatusWidgetExtension;
+ 			productReference = 14B1735C28AED9EC006CCD7C /* Loop Widget Extension.appex */;
+ 			productType = "com.apple.product-type.app-extension";
+@@ -3626,12 +3697,15 @@
+ 			isa = PBXSourcesBuildPhase;
+ 			buildActionMask = 2147483647;
+ 			files = (
++				B87539CB2C2B08430085A975 /* Bootstrap.swift in Sources */,
+ 				14B1738128AEDC70006CCD7C /* StatusExtensionContext.swift in Sources */,
+ 				14B1737628AEDC6C006CCD7C /* HKUnit.swift in Sources */,
+ 				14B1737728AEDC6C006CCD7C /* NSBundle.swift in Sources */,
+ 				84AA81D62A4A28AF000B658B /* WidgetBackground.swift in Sources */,
+ 				84AA81D82A4A2910000B658B /* StatusWidgetTimelimeEntry.swift in Sources */,
+ 				84AA81D32A4A27A3000B658B /* LoopWidgets.swift in Sources */,
++				B87539CF2C2DCB770085A975 /* BasalViewActivity.swift in Sources */,
++				B87539CD2C2B46950085A975 /* ChartView.swift in Sources */,
+ 				84AA81E32A4A36FB000B658B /* SystemActionLink.swift in Sources */,
+ 				14B1737828AEDC6C006CCD7C /* NSTimeInterval.swift in Sources */,
+ 				14B1737928AEDC6C006CCD7C /* NSUserDefaults+StatusExtension.swift in Sources */,
+@@ -3642,7 +3716,10 @@
+ 				14B1737E28AEDC6C006CCD7C /* FeatureFlags.swift in Sources */,
+ 				84AA81E72A4A4DEF000B658B /* PumpView.swift in Sources */,
+ 				14B1737F28AEDC6C006CCD7C /* PluginManager.swift in Sources */,
++				B87D411D2C28A69600120877 /* GlucoseLiveActivityConfiguration.swift in Sources */,
++				B87539C92C2B06CE0085A975 /* LocalizedString.swift in Sources */,
+ 				14B1738028AEDC6C006CCD7C /* Debug.swift in Sources */,
++				B8A937C42C29C43B00E38645 /* GlucoseActivityAttributes.swift in Sources */,
+ 				84AA81DB2A4A2973000B658B /* Date.swift in Sources */,
+ 				14B1737228AEDBF6006CCD7C /* BasalView.swift in Sources */,
+ 				14B1737428AEDBF6006CCD7C /* GlucoseView.swift in Sources */,
+@@ -3728,6 +3805,7 @@
+ 				B4E202302661063E009421B5 /* AutomaticDosingStatus.swift in Sources */,
+ 				C191D2A125B3ACAA00C26C0B /* DosingStrategySelectionView.swift in Sources */,
+ 				A977A2F424ACFECF0059C207 /* CriticalEventLogExportManager.swift in Sources */,
++				B8FD0B522C39CA3E003FB72B /* LiveActivityBottomRowManagerView.swift in Sources */,
+ 				89CA2B32226C18B8004D9350 /* TestingScenariosTableViewController.swift in Sources */,
+ 				43E93FB71E469A5100EAB8DB /* HKUnit.swift in Sources */,
+ 				43C05CAF21EB2C24006FB252 /* NSBundle.swift in Sources */,
+@@ -3735,6 +3813,7 @@
+ 				A967D94C24F99B9300CDDF8A /* OutputStream.swift in Sources */,
+ 				1DB1065124467E18005542BD /* AlertManager.swift in Sources */,
+ 				1D9650C82523FBA100A1370B /* DeviceDataManager+BolusEntryViewModelDelegate.swift in Sources */,
++				B851FFC52C37221800D738C1 /* LiveActivityManagementView.swift in Sources */,
+ 				43C0944A1CACCC73001F6403 /* NotificationManager.swift in Sources */,
+ 				149A28E42A8A63A700052EDF /* FavoriteFoodDetailView.swift in Sources */,
+ 				1DDE274024AEA4F200796622 /* NotificationsCriticalAlertPermissionsView.swift in Sources */,
+@@ -3789,6 +3868,7 @@
+ 				C1AF062329426300002C1B19 /* ManualGlucoseEntryRow.swift in Sources */,
+ 				C148CEE724FD91BD00711B3B /* DeliveryUncertaintyAlertManager.swift in Sources */,
+ 				DDC389FC2A2BC6670066E2E8 /* SettingsView+algorithmExperimentsSection.swift in Sources */,
++				B82181F62C93628300478A91 /* LiveActivityManagementViewModel.swift in Sources */,
+ 				1D12D3B92548EFDD00B53E8B /* main.swift in Sources */,
+ 				435400341C9F878D00D5819C /* SetBolusUserInfo.swift in Sources */,
+ 				A9DCF32A25B0FABF00C89088 /* LoopUIColorPalette+Default.swift in Sources */,
+@@ -3821,11 +3901,13 @@
+ 				A97F250825E056D500F0EE19 /* OnboardingManager.swift in Sources */,
+ 				438D42F91D7C88BC003244B0 /* PredictionInputEffect.swift in Sources */,
+ 				892A5D692230C41D008961AB /* RangeReplaceableCollection.swift in Sources */,
++				B8A937B82C29BA5900E38645 /* GlucoseActivityManager.swift in Sources */,
+ 				DDC389F62A2B61750066E2E8 /* ApplicationFactorStrategy.swift in Sources */,
+ 				4F70C2101DE8FAC5006380B7 /* ExtensionDataManager.swift in Sources */,
+ 				43DFB62320D4CAE7008A7BAE /* PumpManager.swift in Sources */,
+ 				A9FB75F1252BE320004C7D3F /* BolusDosingDecision.swift in Sources */,
+ 				892A5D59222F0A27008961AB /* Debug.swift in Sources */,
++				B82182002C93716A00478A91 /* ChartAxisGenerator.swift in Sources */,
+ 				431A8C401EC6E8AB00823B9C /* CircleMaskView.swift in Sources */,
+ 				1D05219D2469F1F5000EBBDE /* AlertStore.swift in Sources */,
+ 				439897371CD2F80600223065 /* AnalyticsServicesManager.swift in Sources */,
+@@ -3839,6 +3921,7 @@
+ 				439706E622D2E84900C81566 /* PredictionSettingTableViewCell.swift in Sources */,
+ 				430D85891F44037000AF2D4F /* HUDViewTableViewCell.swift in Sources */,
+ 				43A51E211EB6DBDD000736CC /* LoopChartsTableViewController.swift in Sources */,
++				B8A937C32C29C3B400E38645 /* GlucoseActivityAttributes.swift in Sources */,
+ 				8968B1122408B3520074BB48 /* UIFont.swift in Sources */,
+ 				1452F4A92A851C9400F8B9E4 /* AddEditFavoriteFoodViewModel.swift in Sources */,
+ 				438D42FB1D7D11A4003244B0 /* PredictionInputEffectTableViewCell.swift in Sources */,
+@@ -3960,6 +4043,7 @@
+ 				C17DDC9D28AC33A1005FBF4C /* PersistedProperty.swift in Sources */,
+ 				43C05CA921EB2B26006FB252 /* PersistenceController.swift in Sources */,
+ 				A9CE912224CA032E00302A40 /* NSUserDefaults.swift in Sources */,
++				B851FFCB2C3731DE00D738C1 /* LiveActivitySettings.swift in Sources */,
+ 				43C05CAB21EB2B4A006FB252 /* NSBundle.swift in Sources */,
+ 				43C05CC721EC2ABC006FB252 /* IdentifiableClass.swift in Sources */,
+ 				E9B3552B293591E70076AB04 /* MissedMealNotification.swift in Sources */,
+@@ -3981,6 +4065,7 @@
+ 				C17DDC9C28AC339E005FBF4C /* PersistedProperty.swift in Sources */,
+ 				43C05CA821EB2B26006FB252 /* PersistenceController.swift in Sources */,
+ 				43C05CAA21EB2B49006FB252 /* NSBundle.swift in Sources */,
++				B851FFCA2C3731DE00D738C1 /* LiveActivitySettings.swift in Sources */,
+ 				43C05CC821EC2ABC006FB252 /* IdentifiableClass.swift in Sources */,
+ 				43C05CAD21EB2BBF006FB252 /* NSUserDefaults.swift in Sources */,
+ 				E9B3552A293591E70076AB04 /* MissedMealNotification.swift in Sources */,
+@@ -4836,6 +4921,7 @@
+ 				INFOPLIST_FILE = "Loop Widget Extension/Bootstrap/Info.plist";
+ 				INFOPLIST_KEY_CFBundleDisplayName = "Loop Widgets";
+ 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 LoopKit Authors. All rights reserved.";
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+@@ -4884,6 +4970,7 @@
+ 				INFOPLIST_FILE = "Loop Widget Extension/Bootstrap/Info.plist";
+ 				INFOPLIST_KEY_CFBundleDisplayName = "Loop Widgets";
+ 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 LoopKit Authors. All rights reserved.";
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+@@ -5142,6 +5229,7 @@
+ 				DEVELOPMENT_TEAM = "$(LOOP_DEVELOPMENT_TEAM)";
+ 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+ 				INFOPLIST_FILE = Loop/Info.plist;
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+@@ -5171,6 +5259,7 @@
+ 				DEVELOPMENT_TEAM = "$(LOOP_DEVELOPMENT_TEAM)";
+ 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+ 				INFOPLIST_FILE = Loop/Info.plist;
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+@@ -5427,6 +5516,7 @@
+ 				DEVELOPMENT_TEAM = "$(LOOP_DEVELOPMENT_TEAM)";
+ 				ENABLE_BITCODE = NO;
+ 				INFOPLIST_FILE = "Loop Status Extension/Info.plist";
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+@@ -5453,6 +5543,7 @@
+ 				DEVELOPMENT_TEAM = "$(LOOP_DEVELOPMENT_TEAM)";
+ 				ENABLE_BITCODE = NO;
+ 				INFOPLIST_FILE = "Loop Status Extension/Info.plist";
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+@@ -5520,6 +5611,7 @@
+ 				ENABLE_BITCODE = NO;
+ 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+ 				INFOPLIST_FILE = "Loop Intent Extension/Info.plist";
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+@@ -5547,6 +5639,7 @@
+ 				ENABLE_BITCODE = NO;
+ 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+ 				INFOPLIST_FILE = "Loop Intent Extension/Info.plist";
++				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+ 				LD_RUNPATH_SEARCH_PATHS = (
+ 					"$(inherited)",
+ 					"@executable_path/Frameworks",
+diff --git a/Loop/Loop/Info.plist b/Loop/Loop/Info.plist
+index ddad5426..f9f4ca84 100644
+--- a/Loop/Loop/Info.plist
++++ b/Loop/Loop/Info.plist
+@@ -71,6 +71,10 @@
+ 	<string>Carbohydrate meal data entered in the app and on the watch is stored in the Health database. Glucose data retrieved from the CGM is stored securely in HealthKit.</string>
+ 	<key>NSSiriUsageDescription</key>
+ 	<string>Loop uses Siri to allow you to enact presets with your voice.</string>
++	<key>NSSupportsLiveActivities</key>
++	<true/>
++	<key>NSSupportsLiveActivitiesFrequentUpdates</key>
++	<true/>
+ 	<key>NSUserActivityTypes</key>
+ 	<array>
+ 		<string>EnableOverridePresetIntent</string>
+diff --git a/Loop/Loop/Loop.entitlements b/Loop/Loop/Loop.entitlements
+index 50ba55d9..e6a2f9b9 100644
+--- a/Loop/Loop/Loop.entitlements
++++ b/Loop/Loop/Loop.entitlements
+@@ -8,6 +8,8 @@
+ 	<true/>
+ 	<key>com.apple.developer.healthkit.access</key>
+ 	<array/>
++	<key>com.apple.developer.healthkit.background-delivery</key>
++	<true/>
+ 	<key>com.apple.developer.nfc.readersession.formats</key>
+ 	<array>
+ 		<string>TAG</string>
+diff --git a/Loop/Loop/Managers/Live Activity/ChartAxisGenerator.swift b/Loop/Loop/Managers/Live Activity/ChartAxisGenerator.swift
+new file mode 100644
+index 00000000..0fcc3ca8
+--- /dev/null
++++ b/Loop/Loop/Managers/Live Activity/ChartAxisGenerator.swift	
+@@ -0,0 +1,125 @@
++//
++//  ChartAxisGenerator.swift
++//  Loop
++//
++//  Created by Bastiaan Verhaar on 12/09/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import HealthKit
++import SwiftCharts
++import UIKit
++
++struct ChartAxisGenerator {
++    private static let yAxisStepSizeMGDLOverride: Double? = FeatureFlags.predictedGlucoseChartClampEnabled ? 40 : nil
++    private static let range = FeatureFlags.predictedGlucoseChartClampEnabled ? LoopConstants.glucoseChartDefaultDisplayBoundClamped : LoopConstants.glucoseChartDefaultDisplayBound
++    private static let predictedGlucoseSoftBoundsMinimum = FeatureFlags.predictedGlucoseChartClampEnabled ? HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 40) : nil
++    
++    private static let minSegmentCount: Double = 2
++    private static let addPaddingSegmentIfEdge = false
++    private static let axisLabelSettings = ChartLabelSettings(font: .systemFont(ofSize: 14), fontColor: UIColor.secondaryLabel)
++    
++    // This logic is copied/ported from generateYAxisValuesUsingLinearSegmentStep
++    static func getYAxis(points: [Double], isMmol: Bool) -> [Double] {
++        let unit: HKUnit = isMmol ? .millimolesPerLiter : .milligramsPerDeciliter
++
++        let glucoseDisplayRange = [
++            range.lowerBound.doubleValue(for: unit),
++            range.upperBound.doubleValue(for: unit)
++        ]
++        
++        let actualPoints = points + glucoseDisplayRange
++        let sortedChartPoints = actualPoints.sorted {(obj1, obj2) in
++            return obj1 < obj2
++        }
++        
++        guard let first = sortedChartPoints.first, let lastPar = sortedChartPoints.last else {
++            print("Trying to generate Y axis without datapoints, returning empty array")
++            return []
++        }
++        
++        let maxSegmentCount: Double = glucoseValueBelowSoftBoundsMinimum(first, unit) ? 5 : 4
++        
++        guard lastPar >=~ first else {fatalError("Invalid range generating axis values")}
++        let multiple: Double = !isMmol ? (yAxisStepSizeMGDLOverride ?? 25) : 1
++        
++        let last = needsToAddOne(lastPar, first) ? lastPar + 1 : lastPar
++        
++        /// The first axis value will be less than or equal to the first scalar value, aligned with the desired multiple
++        var firstValue = first - (first.truncatingRemainder(dividingBy: multiple))
++        /// The last axis value will be greater than or equal to the last scalar value, aligned with the desired multiple
++        let remainder = last.truncatingRemainder(dividingBy: multiple)
++        var lastValue = remainder == 0 ? last : last + (multiple - remainder)
++        var segmentSize = multiple
++        
++        /// If there should be a padding segment added when a scalar value falls on the first or last axis value, adjust the first and last axis values
++        if firstValue =~ first && addPaddingSegmentIfEdge {
++           firstValue = firstValue - segmentSize
++        }
++        
++        // do not allow the first label to be displayed as -0
++        while firstValue < 0 && firstValue.rounded() == -0 {
++            firstValue = firstValue - segmentSize
++        }
++        
++        if lastValue =~ last && addPaddingSegmentIfEdge {
++            lastValue = lastValue + segmentSize
++        }
++        
++        let distance = lastValue - firstValue
++        var currentMultiple = multiple
++        var segmentCount = distance / currentMultiple
++        var potentialSegmentValues = stride(from: firstValue, to: lastValue, by: currentMultiple)
++
++        /// Find the optimal number of segments and segment width
++        /// If the number of segments is greater than desired, make each segment wider
++        /// ensure no label of -0 will be displayed on the axis
++        while segmentCount > maxSegmentCount ||
++            !potentialSegmentValues.filter({ $0 < 0 && $0.rounded() == -0 }).isEmpty
++        {
++            currentMultiple += multiple
++            segmentCount = distance / currentMultiple
++            potentialSegmentValues = stride(from: firstValue, to: lastValue, by: currentMultiple)
++        }
++        segmentCount = ceil(segmentCount)
++        
++        /// Increase the number of segments until there are enough as desired
++        while segmentCount < minSegmentCount {
++            segmentCount += 1
++        }
++        segmentSize = currentMultiple
++        
++        /// Generate axis values from the first value, segment size and number of segments
++        let offset = firstValue
++        return (0...Int(segmentCount)).map {segment in
++            var scalar = offset + (Double(segment) * segmentSize)
++            // a value that could be displayed as 0 should truly be 0 to have the zero-line drawn correctly.
++            if scalar != 0,
++                scalar.rounded() == 0
++            {
++                scalar = 0
++            }
++            return ChartAxisValueDouble(scalar, labelSettings: axisLabelSettings).scalar
++        }
++    }
++    
++    private static func needsToAddOne(_ a: Double, _ b: Double) -> Bool {
++        return fabs(a - b) < Double.ulpOfOne
++    }
++    
++    private static func glucoseValueBelowSoftBoundsMinimum(_ glucoseMinimum: Double, _ unit: HKUnit) -> Bool {
++        guard let predictedGlucoseSoftBoundsMinimum = predictedGlucoseSoftBoundsMinimum else
++        {
++            return false
++        }
++            
++        return HKQuantity(unit: unit, doubleValue: glucoseMinimum) < predictedGlucoseSoftBoundsMinimum
++    }
++}
++
++fileprivate extension Double {
++    static func >=~ (a: Double, b: Double) -> Bool {
++        return a =~ b || a > b
++    }
++}
+diff --git a/Loop/Loop/Managers/Live Activity/GlucoseActivityAttributes.swift b/Loop/Loop/Managers/Live Activity/GlucoseActivityAttributes.swift
+new file mode 100644
+index 00000000..936de751
+--- /dev/null
++++ b/Loop/Loop/Managers/Live Activity/GlucoseActivityAttributes.swift	
+@@ -0,0 +1,151 @@
++//
++//  LiveActivityAttributes.swift
++//  LoopUI
++//
++//  Created by Bastiaan Verhaar on 23/06/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import ActivityKit
++import Foundation
++import LoopKit
++import LoopCore
++
++public struct GlucoseActivityAttributes: ActivityAttributes {
++    public struct ContentState: Codable, Hashable {
++        // Meta data
++        public let date: Date
++        public let ended: Bool
++        public let preset: Preset?
++        public let glucoseRanges: [GlucoseRangeValue]
++        
++        // Dynamic island data
++        public let currentGlucose: Double
++        public let trendType: GlucoseTrend?
++        public let delta: String
++        public let isMmol: Bool
++        
++        // Loop circle
++        public let isCloseLoop: Bool
++        public let lastCompleted: Date?
++        
++        // Bottom row
++        public let bottomRow: [BottomRowItem]
++        
++        // Chart view
++        public let glucoseSamples: [GlucoseSampleAttributes]
++        public let predicatedGlucose: [Double]
++        public let predicatedStartDate: Date?
++        public let predicatedInterval: TimeInterval?
++        public let yAxisMarks: [Double]
++    }
++    
++    public let mode: LiveActivityMode
++    public let addPredictiveLine: Bool
++    public let useLimits: Bool
++    public let upperLimitChartMmol: Double
++    public let lowerLimitChartMmol: Double
++    public let upperLimitChartMg: Double
++    public let lowerLimitChartMg: Double
++}
++
++public struct Preset: Codable, Hashable {
++    public let title: String
++    public let startDate: Date
++    public let endDate: Date
++    public let minValue: Double
++    public let maxValue: Double
++}
++
++public struct GlucoseRangeValue: Identifiable, Codable, Hashable {
++    public let id: UUID
++    public let minValue: Double
++    public let maxValue: Double
++    public let startDate: Date
++    public let endDate: Date
++}
++
++public struct BottomRowItem: Codable, Hashable {
++    public enum BottomRowType: Codable, Hashable {
++        case generic
++        case basal
++        case currentBg
++        case loopCircle
++    }
++    
++    public let type: BottomRowType
++    
++    // Generic properties
++    public let label: String
++    public let value: String
++    public let unit: String
++    
++    public let trend: GlucoseTrend?
++
++    // Basal properties
++    public let rate: Double
++    public let percentage: Double
++    
++    private init(type: BottomRowType, label: String?, value: String?, unit: String?, trend: GlucoseTrend?, rate: Double?, percentage: Double?) {
++        self.type = type
++        self.label = label ?? ""
++        self.value = value ?? ""
++        self.trend = trend
++        self.unit = unit ?? ""
++        self.rate = rate ?? 0
++        self.percentage = percentage ?? 0
++    }
++    
++    static func generic(label: String, value: String, unit: String) -> BottomRowItem  {
++        return BottomRowItem(
++            type: .generic,
++            label: label,
++            value: value,
++            unit: unit,
++            trend: nil,
++            rate: nil,
++            percentage: nil
++        )
++    }
++    
++    static func basal(rate: Double, percentage: Double) -> BottomRowItem {
++        return BottomRowItem(
++            type: .basal,
++            label: nil,
++            value: nil,
++            unit: nil,
++            trend: nil,
++            rate: rate,
++            percentage: percentage
++        )
++    }
++    
++    static func currentBg(label: String, value: String, trend: GlucoseTrend?) -> BottomRowItem {
++        return BottomRowItem(
++            type: .currentBg,
++            label: label,
++            value: value,
++            unit: nil,
++            trend: trend,
++            rate: nil,
++            percentage: nil
++        )
++    }
++    
++    static func loopIcon() -> BottomRowItem {
++        return BottomRowItem(
++            type: .loopCircle,
++            label: nil,
++            value: nil,
++            unit: nil,
++            trend: nil,
++            rate: nil,
++            percentage: nil
++        )
++    }
++}
++
++public struct GlucoseSampleAttributes: Codable, Hashable {
++    public let x: Date
++    public let y: Double
++}
+diff --git a/Loop/Loop/Managers/Live Activity/GlucoseActivityManager.swift b/Loop/Loop/Managers/Live Activity/GlucoseActivityManager.swift
+new file mode 100644
+index 00000000..3903ee8b
+--- /dev/null
++++ b/Loop/Loop/Managers/Live Activity/GlucoseActivityManager.swift	
+@@ -0,0 +1,520 @@
++//
++//  LiveActivityManaer.swift
++//  Loop
++//
++//  Created by Bastiaan Verhaar on 24/06/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import LoopKitUI
++import LoopKit
++import LoopCore
++import Foundation
++import HealthKit
++import ActivityKit
++
++extension Notification.Name {
++    static let LiveActivitySettingsChanged = Notification.Name(rawValue: "com.loopKit.notification.LiveActivitySettingsChanged")
++}
++
++@available(iOS 16.2, *)
++class GlucoseActivityManager {
++    private let activityInfo = ActivityAuthorizationInfo()
++    private var activity: Activity<GlucoseActivityAttributes>?
++    private let healthStore = HKHealthStore()
++    
++    private let glucoseStore: GlucoseStoreProtocol
++    private let doseStore: DoseStoreProtocol
++    private var loopSettings: LoopSettings
++    
++    private var startDate: Date = Date.now
++    private var settings: LiveActivitySettings = UserDefaults.standard.liveActivity ?? LiveActivitySettings()
++    
++    private let cobFormatter: NumberFormatter =  {
++        let numberFormatter = NumberFormatter()
++        numberFormatter.numberStyle = .none
++        return numberFormatter
++    }()
++    private let iobFormatter: NumberFormatter =  {
++        let numberFormatter = NumberFormatter()
++        numberFormatter.numberStyle = .none
++        numberFormatter.maximumFractionDigits = 1
++        numberFormatter.minimumFractionDigits = 1
++        return numberFormatter
++    }()
++    private let timeFormatter: DateFormatter = {
++        let dateFormatter = DateFormatter()
++        dateFormatter.dateStyle = .none
++        dateFormatter.timeStyle = .short
++        
++        return dateFormatter
++    }()
++    
++    init?(glucoseStore: GlucoseStoreProtocol, doseStore: DoseStoreProtocol, loopSettings: LoopSettings) {
++        guard self.activityInfo.areActivitiesEnabled else {
++            print("ERROR: Live Activities are not enabled...")
++            return nil
++        }
++        
++        self.glucoseStore = glucoseStore
++        self.doseStore = doseStore
++        self.loopSettings = loopSettings
++        
++        // Ensure settings exist
++        if UserDefaults.standard.liveActivity == nil {
++            self.settings = LiveActivitySettings()
++        }
++        
++        let nc = NotificationCenter.default
++        nc.addObserver(self, selector: #selector(self.appMovedToForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
++        nc.addObserver(self, selector: #selector(self.settingsChanged), name: .LiveActivitySettingsChanged, object: nil)
++        guard self.settings.enabled else {
++            return
++        }
++        
++        initEmptyActivity(settings: self.settings)
++        update()
++        
++        Task {
++            await self.endUnknownActivities()
++        }
++    }
++    
++    public func update(loopSettings: LoopSettings) {
++        self.loopSettings = loopSettings
++        update()
++    }
++    
++    private func update() {
++        Task {
++            if self.needsRecreation(), await UIApplication.shared.applicationState == .active {
++                // activity is no longer visible or old. End it and try to push the update again
++                print("INFO: Live Activities needs recreation")
++                await endActivity()
++                update()
++                return
++            }
++            
++            guard let unit = await self.healthStore.cachedPreferredUnits(for: .bloodGlucose) else {
++                print("ERROR: No unit found...")
++                return
++            }
++            
++            await self.endUnknownActivities()
++
++            let statusContext = UserDefaults.appGroup?.statusExtensionContext
++            let glucoseFormatter = NumberFormatter.glucoseFormatter(for: unit)
++            
++            let glucoseSamples = self.getGlucoseSample(unit: unit)
++            guard let currentGlucose = glucoseSamples.last else {
++                print("ERROR: No glucose sample found...")
++                return
++            }
++            
++            let current = currentGlucose.quantity.doubleValue(for: unit)
++            
++            var delta: String = "+\(glucoseFormatter.string(from: Double(0)) ?? "")"
++            if glucoseSamples.count > 1 {
++                let prevSample = glucoseSamples[glucoseSamples.count - 2]
++                let deltaValue = current - (prevSample.quantity.doubleValue(for: unit))
++                delta = "\(deltaValue < 0 ? "-" : "+")\(glucoseFormatter.string(from: abs(deltaValue)) ?? "??")"
++            }
++            
++            
++            let bottomRow = self.getBottomRow(
++                currentGlucose: current,
++                delta: delta,
++                statusContext: statusContext,
++                glucoseFormatter: glucoseFormatter
++            )
++            
++            var predicatedGlucose: [Double] = []
++            if let samples = statusContext?.predictedGlucose?.values, settings.addPredictiveLine {
++                predicatedGlucose = samples
++            }
++            
++            var endDateChart: Date? = nil
++            if predicatedGlucose.count == 0 {
++                endDateChart = glucoseSamples.last?.startDate
++            } else if let predictedGlucose = statusContext?.predictedGlucose {
++                endDateChart = predictedGlucose.startDate.addingTimeInterval(.hours(4))
++            }
++            
++            guard let endDateChart = endDateChart else {
++                return
++            }
++            
++            var presetContext: Preset? = nil
++            if let override = self.loopSettings.preMealOverride ?? self.loopSettings.scheduleOverride, let start = glucoseSamples.first?.startDate {
++                presetContext = Preset(
++                    title: override.getTitle(),
++                    startDate: max(override.startDate, start),
++                    endDate: override.duration.isInfinite ? endDateChart : min(override.actualEndDate, endDateChart),
++                    minValue: override.settings.targetRange?.lowerBound.doubleValue(for: unit) ?? 0,
++                    maxValue: override.settings.targetRange?.upperBound.doubleValue(for: unit) ?? 0
++                )
++            }
++            
++            var glucoseRanges: [GlucoseRangeValue] = []
++            if let glucoseRangeSchedule = self.loopSettings.glucoseTargetRangeSchedule, let start = glucoseSamples.first?.startDate {
++                glucoseRanges = getGlucoseRanges(
++                    glucoseRangeSchedule: glucoseRangeSchedule,
++                    presetContext: presetContext,
++                    start: start,
++                    end: endDateChart,
++                    unit: unit
++                )
++            }
++            
++            let yAxisPoints = glucoseSamples.map{ item in item.quantity.doubleValue(for: unit) } + predicatedGlucose
++            let chartYAxis = ChartAxisGenerator.getYAxis(
++                points: yAxisPoints,
++                isMmol: unit == HKUnit.millimolesPerLiter
++            )
++
++            let state = GlucoseActivityAttributes.ContentState(
++                date: currentGlucose.startDate,
++                ended: false,
++                preset: presetContext,
++                glucoseRanges: glucoseRanges,
++                currentGlucose: current,
++                trendType: statusContext?.glucoseDisplay?.trendType,
++                delta: delta,
++                isMmol: unit == HKUnit.millimolesPerLiter,
++                isCloseLoop: statusContext?.isClosedLoop ?? false,
++                lastCompleted: statusContext?.lastLoopCompleted,
++                bottomRow: bottomRow,
++                // In order to prevent maxSize errors, only allow the last 100 samples to be sent
++                // Will most likely not be an issue, might be an issue for debugging/CGM simulator with 5sec interval
++                glucoseSamples: glucoseSamples.suffix(100).map { item in
++                    return GlucoseSampleAttributes(x: item.startDate, y: item.quantity.doubleValue(for: unit))
++                },
++                predicatedGlucose: predicatedGlucose,
++                predicatedStartDate: statusContext?.predictedGlucose?.startDate,
++                predicatedInterval: statusContext?.predictedGlucose?.interval,
++                yAxisMarks: chartYAxis
++            )
++            
++            await self.activity?.update(ActivityContent(
++                state: state,
++                staleDate: Date.now.addingTimeInterval(.hours(1))
++            ))
++        }
++    }
++    
++    @objc private func settingsChanged() {
++        Task {
++            let newSettings = UserDefaults.standard.liveActivity ?? LiveActivitySettings()
++            
++            // Update live activity if needed
++            if !newSettings.enabled, let activity = self.activity {
++                await activity.end(nil, dismissalPolicy: .immediate)
++                self.activity = nil
++                
++                return
++            } else if newSettings.enabled && self.activity == nil {
++                initEmptyActivity(settings: newSettings)
++                
++            } else if newSettings != self.settings {
++                await self.activity?.end(nil, dismissalPolicy: .immediate)
++                self.activity = nil
++                
++                initEmptyActivity(settings: newSettings)
++            }
++            
++            self.settings = newSettings
++            update()
++        }
++    }
++    
++    @objc private func appMovedToForeground() {
++        guard self.settings.enabled else {
++            return
++        }
++        
++        guard let activity = self.activity else {
++            initEmptyActivity(settings: self.settings)
++            update()
++            return
++        }
++        
++        Task {
++            await activity.end(nil, dismissalPolicy: .immediate)
++            await self.endUnknownActivities()
++            self.activity = nil
++            
++            initEmptyActivity(settings: self.settings)
++            update()
++        }
++    }
++    
++    private func endUnknownActivities() async {
++        for unknownActivity in Activity<GlucoseActivityAttributes>.activities
++            .filter({ self.activity?.id != $0.id })
++        {
++            await unknownActivity.end(nil, dismissalPolicy: .immediate)
++        }
++    }
++    
++    private func endActivity() async {
++        let dynamicState = self.activity?.content.state
++        
++        await self.activity?.end(nil, dismissalPolicy: .immediate)
++        for unknownActivity in Activity<GlucoseActivityAttributes>.activities {
++            await unknownActivity.end(nil, dismissalPolicy: .immediate)
++        }
++        
++        do {
++            if let dynamicState = dynamicState {
++                self.activity = try Activity.request(
++                    attributes: GlucoseActivityAttributes(
++                        mode: self.settings.mode,
++                        addPredictiveLine: self.settings.addPredictiveLine,
++                        useLimits: self.settings.useLimits,
++                        upperLimitChartMmol: self.settings.upperLimitChartMmol,
++                        lowerLimitChartMmol: self.settings.lowerLimitChartMmol,
++                        upperLimitChartMg: self.settings.upperLimitChartMg,
++                        lowerLimitChartMg: self.settings.lowerLimitChartMg
++                    ),
++                    content: .init(state: dynamicState, staleDate: nil),
++                    pushType: .token
++                )
++            }
++            self.startDate = Date.now
++        } catch {
++            print("ERROR: Error while ending live activity: \(error.localizedDescription)")
++        }
++    }
++    
++    private func needsRecreation() -> Bool {
++        if !self.settings.enabled {
++            return false
++        }
++        
++        switch activity?.activityState {
++        case .dismissed,
++             .ended,
++             .stale:
++            return true
++        case .active:
++            return -startDate.timeIntervalSinceNow > .hours(1)
++        default:
++            return true
++        }
++    }
++    
++    private func getInsulinOnBoard() -> String {
++        let updateGroup = DispatchGroup()
++        var iob = "??"
++        
++        updateGroup.enter()
++        self.doseStore.insulinOnBoard(at: Date.now) { result in
++            switch (result) {
++            case .failure:
++                break
++            case .success(let iobValue):
++                iob = self.iobFormatter.string(from: iobValue.value) ?? "??"
++                break
++            }
++            
++            updateGroup.leave()
++        }
++        
++        _ = updateGroup.wait(timeout: .distantFuture)
++        return iob
++    }
++    
++    private func getGlucoseSample(unit: HKUnit) -> [StoredGlucoseSample] {
++        let updateGroup = DispatchGroup()
++        var samples: [StoredGlucoseSample] = []
++        
++        updateGroup.enter()
++        
++        // When in spacious mode, we want to show the predictive line
++        // In compact mode, we only want to show the history
++        let timeInterval: TimeInterval = self.settings.addPredictiveLine ? .hours(-2) : .hours(-6)
++        self.glucoseStore.getGlucoseSamples(
++            start: Date.now.addingTimeInterval(timeInterval),
++            end: Date.now
++        ) { result in
++            switch (result) {
++            case .failure:
++                break
++            case .success(let data):
++                samples = data
++                break
++            }
++            
++            updateGroup.leave()
++        }
++        
++        _ = updateGroup.wait(timeout: .distantFuture)
++        return samples
++    }
++    
++    private func getGlucoseRanges(glucoseRangeSchedule: GlucoseRangeSchedule, presetContext: Preset?, start: Date, end: Date, unit: HKUnit) -> [GlucoseRangeValue] {
++        var glucoseRanges: [GlucoseRangeValue] = []
++        for item in glucoseRangeSchedule.quantityBetween(start: start, end: end) {
++            let minValue = item.value.lowerBound.doubleValue(for: unit)
++            let maxValue = item.value.upperBound.doubleValue(for: unit)
++            let startDate = max(item.startDate, start)
++            let endDate = min(item.endDate, end)
++            
++            if let presetContext = presetContext {
++                if presetContext.startDate > startDate, presetContext.endDate < endDate {
++                    // A preset is active during this schedule
++                    glucoseRanges.append(GlucoseRangeValue(
++                        id: UUID(),
++                        minValue: minValue,
++                        maxValue: maxValue,
++                        startDate: startDate,
++                        endDate: presetContext.startDate
++                    ))
++                    glucoseRanges.append(GlucoseRangeValue(
++                        id: UUID(),
++                        minValue: minValue,
++                        maxValue: maxValue,
++                        startDate: presetContext.endDate,
++                        endDate: endDate
++                    ))
++                } else if presetContext.endDate > startDate, presetContext.endDate < endDate {
++                    // Cut off the start of the glucose target
++                    glucoseRanges.append(GlucoseRangeValue(
++                        id: UUID(),
++                        minValue: minValue,
++                        maxValue: maxValue,
++                        startDate: presetContext.endDate,
++                        endDate: endDate
++                    ))
++                } else if presetContext.startDate < endDate, presetContext.startDate > startDate {
++                    // Cut off the end of the glucose target
++                    glucoseRanges.append(GlucoseRangeValue(
++                        id: UUID(),
++                        minValue: minValue,
++                        maxValue: maxValue,
++                        startDate: startDate,
++                        endDate: presetContext.startDate
++                    ))
++                    if presetContext.endDate == end {
++                        break
++                    }
++                } else {
++                    // No overlap with target and override
++                    glucoseRanges.append(GlucoseRangeValue(
++                        id: UUID(),
++                        minValue: minValue,
++                        maxValue: maxValue,
++                        startDate: startDate,
++                        endDate: endDate
++                    ))
++                }
++            } else {
++                glucoseRanges.append(GlucoseRangeValue(
++                    id: UUID(),
++                    minValue: minValue,
++                    maxValue: maxValue,
++                    startDate: startDate,
++                    endDate: endDate
++                ))
++            }
++        }
++        
++        return glucoseRanges
++    }
++    
++    private func getBottomRow(currentGlucose: Double, delta: String, statusContext: StatusExtensionContext?, glucoseFormatter: NumberFormatter) -> [BottomRowItem] {
++        return self.settings.bottomRowConfiguration.map { type in
++            switch(type) {
++            case .iob:
++                return BottomRowItem.generic(label: type.name(), value: getInsulinOnBoard(), unit: "U")
++                
++            case .cob:
++                var cob: String = "0"
++                if let cobValue = statusContext?.carbsOnBoard {
++                    cob = self.cobFormatter.string(from: cobValue) ?? "??"
++                }
++                return BottomRowItem.generic(label: type.name(), value: cob, unit: "g")
++                
++            case .basal:
++                guard let netBasalContext = statusContext?.netBasal else {
++                    return BottomRowItem.basal(rate: 0, percentage: 0)
++                }
++
++                return BottomRowItem.basal(rate: netBasalContext.rate, percentage: netBasalContext.percentage)
++                
++            case .currentBg:
++                return BottomRowItem.currentBg(label: type.name(), value: "\(glucoseFormatter.string(from: currentGlucose) ?? "??")", trend: statusContext?.glucoseDisplay?.trendType)
++                
++            case .eventualBg:
++                guard let eventual = statusContext?.predictedGlucose?.values.last else {
++                    return BottomRowItem.generic(label: type.name(), value: "??", unit: "")
++                }
++                
++                return BottomRowItem.generic(label: type.name(), value: glucoseFormatter.string(from: eventual) ?? "??", unit: "")
++                
++            case .deltaBg:
++                return BottomRowItem.generic(label: type.name(), value: delta, unit: "")
++                
++            case .loopCircle:
++                return BottomRowItem.loopIcon()
++                
++            case .updatedAt:
++                return BottomRowItem.generic(label: type.name(), value: timeFormatter.string(from: Date.now), unit: "")
++            }
++       }
++    }
++    
++    private func initEmptyActivity(settings: LiveActivitySettings) {
++        do {
++            let dynamicState = GlucoseActivityAttributes.ContentState(
++                date: Date.now,
++                ended: true,
++                preset: nil,
++                glucoseRanges: [],
++                currentGlucose: 0,
++                trendType: nil,
++                delta: "",
++                isMmol: true,
++                isCloseLoop: false,
++                lastCompleted: nil,
++                bottomRow: [],
++                glucoseSamples: [],
++                predicatedGlucose: [],
++                predicatedStartDate: nil,
++                predicatedInterval: nil,
++                yAxisMarks: []
++            )
++            
++            self.activity = try Activity.request(
++                attributes: GlucoseActivityAttributes(
++                    mode: settings.mode,
++                    addPredictiveLine: settings.addPredictiveLine,
++                    useLimits: settings.useLimits,
++                    upperLimitChartMmol: settings.upperLimitChartMmol,
++                    lowerLimitChartMmol: settings.lowerLimitChartMmol,
++                    upperLimitChartMg: settings.upperLimitChartMg,
++                    lowerLimitChartMg: settings.lowerLimitChartMg
++                ),
++                content: .init(state: dynamicState, staleDate: nil),
++                pushType: .token
++            )
++        } catch {
++            print("ERROR: Error while creating empty live activity: \(error.localizedDescription)")
++        }
++    }
++}
++
++extension TemporaryScheduleOverride {
++    func getTitle() -> String {
++        switch (self.context) {
++        case .preset(let preset):
++            return "\(preset.symbol) \(preset.name)"
++        case .custom:
++            return NSLocalizedString("Custom preset", comment: "The title of the cell indicating a generic custom preset is enabled")
++        case .preMeal:
++            return NSLocalizedString(" Pre-meal Preset", comment: "Status row title for premeal override enabled (leading space is to separate from symbol)")
++        case .legacyWorkout:
++            return ""
++        }
++    }
++}
+diff --git a/Loop/Loop/Managers/LoopDataManager.swift b/Loop/Loop/Managers/LoopDataManager.swift
+index 5e47cbc3..5aa9c4fd 100644
+--- a/Loop/Loop/Managers/LoopDataManager.swift
++++ b/Loop/Loop/Managers/LoopDataManager.swift
+@@ -68,6 +68,8 @@ final class LoopDataManager {
+     private var timeBasedDoseApplicationFactor: Double = 1.0
+ 
+     private var insulinOnBoard: InsulinValue?
++    
++    private var liveActivityManager: GlucoseActivityManager?
+ 
+     deinit {
+         for observer in notificationObservers {
+@@ -124,6 +126,12 @@ final class LoopDataManager {
+         self.automaticDosingStatus = automaticDosingStatus
+ 
+         self.trustedTimeOffset = trustedTimeOffset
++        
++        self.liveActivityManager = GlucoseActivityManager(
++            glucoseStore: self.glucoseStore,
++            doseStore: self.doseStore,
++            loopSettings: self.settings
++        )
+ 
+         overrideIntentObserver = UserDefaults.appGroup?.observe(\.intentExtensionOverrideToSet, options: [.new], changeHandler: {[weak self] (defaults, change) in
+             guard let name = change.newValue??.lowercased(), let appGroup = UserDefaults.appGroup else {
+@@ -144,12 +152,14 @@ final class LoopDataManager {
+                         }
+                     }
+                 }
++                
+                 settings.scheduleOverride = preset.createOverride(enactTrigger: .remote("Siri"))
+                 if let observers = self?.presetActivationObservers {
+                     for observer in observers {
+                         observer.presetActivated(context: .preset(preset), duration: preset.duration)
+                     }
+                 }
++                self?.liveActivityManager?.update(loopSettings: settings)
+             }
+             // Remove the override from UserDefaults so we don't set it multiple times
+             appGroup.intentExtensionOverrideToSet = nil
+@@ -167,6 +177,7 @@ final class LoopDataManager {
+             ) { (note) -> Void in
+                 self.dataAccessQueue.async {
+                     self.logger.default("Received notification of carb entries changing")
++                    self.liveActivityManager?.update(loopSettings: self.settings)
+ 
+                     self.carbEffect = nil
+                     self.carbsOnBoard = nil
+@@ -182,7 +193,8 @@ final class LoopDataManager {
+             ) { (note) in
+                 self.dataAccessQueue.async {
+                     self.logger.default("Received notification of glucose samples changing")
+-
++                    self.liveActivityManager?.update(loopSettings: self.settings)
++                    
+                     self.glucoseMomentumEffect = nil
+                     self.remoteRecommendationNeedsUpdating = true
+ 
+@@ -196,6 +208,7 @@ final class LoopDataManager {
+             ) { (note) in
+                 self.dataAccessQueue.async {
+                     self.logger.default("Received notification of dosing changing")
++                    self.liveActivityManager?.update(loopSettings: self.settings)
+ 
+                     self.clearCachedInsulinEffects()
+                     self.remoteRecommendationNeedsUpdating = true
+@@ -247,6 +260,8 @@ final class LoopDataManager {
+         if newValue.preMealOverride != oldValue.preMealOverride {
+             // The prediction isn't actually invalid, but a target range change requires recomputing recommended doses
+             predictedGlucose = nil
++            
++            self.liveActivityManager?.update(loopSettings: newValue)
+         }
+ 
+         if newValue.scheduleOverride != oldValue.scheduleOverride {
+@@ -256,12 +271,14 @@ final class LoopDataManager {
+                 for observer in self.presetActivationObservers {
+                     observer.presetDeactivated(context: oldPreset.context)
+                 }
+-
++                self.liveActivityManager?.update(loopSettings: newValue)
+             }
+             if let newPreset = newValue.scheduleOverride {
+                 for observer in self.presetActivationObservers {
+                     observer.presetActivated(context: newPreset.context, duration: newPreset.duration)
+                 }
++                
++                self.liveActivityManager?.update(loopSettings: newValue)
+             }
+ 
+             // Invalidate cached effects affected by the override
+diff --git a/Loop/Loop/View Models/LiveActivityManagementViewModel.swift b/Loop/Loop/View Models/LiveActivityManagementViewModel.swift
+new file mode 100644
+index 00000000..46fc560d
+--- /dev/null
++++ b/Loop/Loop/View Models/LiveActivityManagementViewModel.swift	
+@@ -0,0 +1,35 @@
++//
++//  LiveActivityManagementViewModel.swift
++//  Loop
++//
++//  Created by Bastiaan Verhaar on 12/09/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import LoopCore
++
++class LiveActivityManagementViewModel : ObservableObject {
++    @Published var enabled: Bool
++    @Published var mode: LiveActivityMode
++    @Published var isEditingMode: Bool = false
++    @Published var addPredictiveLine: Bool
++    @Published var useLimits: Bool
++    @Published var upperLimitChartMmol: Double
++    @Published var lowerLimitChartMmol: Double
++    @Published var upperLimitChartMg: Double
++    @Published var lowerLimitChartMg: Double
++    
++    init() {
++        let liveActivitySettings = UserDefaults.standard.liveActivity ?? LiveActivitySettings()
++        
++        self.enabled = liveActivitySettings.enabled
++        self.mode = liveActivitySettings.mode
++        self.addPredictiveLine = liveActivitySettings.addPredictiveLine
++        self.useLimits = liveActivitySettings.useLimits
++        self.upperLimitChartMmol = liveActivitySettings.upperLimitChartMmol
++        self.lowerLimitChartMmol = liveActivitySettings.lowerLimitChartMmol
++        self.upperLimitChartMg = liveActivitySettings.upperLimitChartMg
++        self.lowerLimitChartMg = liveActivitySettings.lowerLimitChartMg
++    }
++}
+diff --git a/Loop/Loop/Views/AlertManagementView.swift b/Loop/Loop/Views/AlertManagementView.swift
+index e9a38e72..94e542a6 100644
+--- a/Loop/Loop/Views/AlertManagementView.swift
++++ b/Loop/Loop/Views/AlertManagementView.swift
+@@ -7,8 +7,10 @@
+ //
+ 
+ import SwiftUI
++import LoopCore
+ import LoopKit
+ import LoopKitUI
++import HealthKit
+ 
+ struct AlertManagementView: View {
+     @Environment(\.appName) private var appName
+@@ -157,6 +159,11 @@ struct AlertManagementView: View {
+                     }
+                 }
+             }
++            
++            NavigationLink(destination: LiveActivityManagementView())
++            {
++                    Text(NSLocalizedString("Live activity", comment: "Alert Permissions live activity"))
++            }
+         }
+     }
+ 
+diff --git a/Loop/Loop/Views/LiveActivityBottomRowManagerView.swift b/Loop/Loop/Views/LiveActivityBottomRowManagerView.swift
+new file mode 100644
+index 00000000..49e50caa
+--- /dev/null
++++ b/Loop/Loop/Views/LiveActivityBottomRowManagerView.swift
+@@ -0,0 +1,117 @@
++//
++//  LiveActivityBottomRowManagerView.swift
++//  Loop
++//
++//  Created by Bastiaan Verhaar on 06/07/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import LoopKitUI
++import LoopCore
++import SwiftUI
++
++struct LiveActivityBottomRowManagerView: View {
++    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
++
++    // The maximum items in the bottom row
++    private let maxSize = 4
++    
++    @State var showAdd: Bool = false
++    @State var configuration: [BottomRowConfiguration] = (UserDefaults.standard.liveActivity ?? LiveActivitySettings()).bottomRowConfiguration
++    
++    var addItem: ActionSheet {
++        var buttons: [ActionSheet.Button] = BottomRowConfiguration.all.map { item in
++            ActionSheet.Button.default(Text(item.description())) {
++                configuration.append(item)
++            }
++        }
++        buttons.append(.cancel(Text(NSLocalizedString("Cancel", comment: "Button text to cancel"))))
++        
++        return ActionSheet(title: Text(NSLocalizedString("Add item to bottom row", comment: "Title for Add item")), buttons: buttons)
++    }
++    
++    var body: some View {
++        List {
++            ForEach($configuration, id: \.self) { item in
++                HStack {
++                    deleteButton
++                        .onTapGesture {
++                            onDelete(item.wrappedValue)
++                        }
++                    Text(item.wrappedValue.description())
++                    
++                    Spacer()
++                    editBars
++                }
++            }
++                .onMove(perform: onReorder)
++                .deleteDisabled(true)
++            
++            Section {
++                Button(action: onSave) {
++                    Text(NSLocalizedString("Save", comment: ""))
++                }
++                .buttonStyle(ActionButtonStyle())
++                .listRowInsets(EdgeInsets())
++            }
++        }
++            .toolbar {
++                ToolbarItem(placement: .navigationBarTrailing) {
++                    Button(
++                        action: { showAdd = true },
++                        label: { Image(systemName: "plus") }
++                    )
++                    .disabled(configuration.count >= self.maxSize)
++                }
++            }
++            .actionSheet(isPresented: $showAdd, content: { addItem })
++            .insetGroupedListStyle()
++            .navigationBarTitle(Text(NSLocalizedString("Bottom row", comment: "Live activity Bottom row configuration title")))
++    }
++    
++    @ViewBuilder
++    private var deleteButton: some View {
++        ZStack {
++            Color.red
++                .clipShape(RoundedRectangle(cornerRadius: 12.5))
++                .frame(width: 20, height: 20)
++            
++            Image(systemName: "minus")
++                .foregroundColor(.white)
++        }
++        .contentShape(Rectangle())
++    }
++    
++    @ViewBuilder
++    private var editBars: some View {
++        Image(systemName: "line.3.horizontal")
++            .foregroundColor(Color(UIColor.tertiaryLabel))
++            .font(.title2)
++    }
++    
++    private func onSave() {
++        var settings = UserDefaults.standard.liveActivity ?? LiveActivitySettings()
++        settings.bottomRowConfiguration = configuration
++        
++        UserDefaults.standard.liveActivity = settings
++        NotificationCenter.default.post(name: .LiveActivitySettingsChanged, object: settings)
++        
++        self.presentationMode.wrappedValue.dismiss()
++    }
++    
++    func onReorder(from: IndexSet, to: Int) {
++        withAnimation {
++            configuration.move(fromOffsets: from, toOffset: to)
++        }
++    }
++    
++    func onDelete(_ item: BottomRowConfiguration) {
++        withAnimation {
++            _ = configuration.remove(item)
++        }
++    }
++}
++
++#Preview {
++    LiveActivityBottomRowManagerView()
++}
+diff --git a/Loop/Loop/Views/LiveActivityManagementView.swift b/Loop/Loop/Views/LiveActivityManagementView.swift
+new file mode 100644
+index 00000000..f7f875ca
+--- /dev/null
++++ b/Loop/Loop/Views/LiveActivityManagementView.swift
+@@ -0,0 +1,113 @@
++//
++//  LiveActivityManagementView.swift
++//  Loop
++//
++//  Created by Bastiaan Verhaar on 04/07/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import SwiftUI
++import LoopKitUI
++import LoopCore
++import HealthKit
++
++struct LiveActivityManagementView: View {
++    @EnvironmentObject private var displayGlucosePreference: DisplayGlucosePreference
++    @StateObject private var viewModel = LiveActivityManagementViewModel()
++   
++    var body: some View {
++        VStack {
++            List {
++                Section {
++                    Toggle(NSLocalizedString("Enabled", comment: "Title for enable live activity toggle"), isOn: $viewModel.enabled)
++                    
++                    ExpandableSetting(
++                        isEditing: $viewModel.isEditingMode,
++                        leadingValueContent: {
++                            Text(NSLocalizedString("Mode", comment: "Title for mode live activity toggle"))
++                                .foregroundStyle(viewModel.isEditingMode ? .blue : .primary)
++                        },
++                        trailingValueContent: {
++                            Text(viewModel.mode.name())
++                                .foregroundStyle(viewModel.isEditingMode ? .blue : .primary)
++                        },
++                        expandedContent: {
++                            ResizeablePicker(selection: self.$viewModel.mode.animation(),
++                                             data: LiveActivityMode.all,
++                                             formatter: { $0.name() })
++                        }
++                    )
++                }
++                
++                Section {
++                    if viewModel.mode == .large {
++                        Toggle(NSLocalizedString("Add predictive line", comment: "Title for predictive line toggle"), isOn: $viewModel.addPredictiveLine)
++                            .transition(.move(edge: viewModel.mode == .large ? .top : .bottom))
++                    }
++                    
++                    Toggle(NSLocalizedString("Use BG coloring", comment: "Title for BG coloring"), isOn: $viewModel.useLimits)
++                        .transition(.move(edge: viewModel.mode == .large ? .top : .bottom))
++                    
++                    if viewModel.useLimits {
++                        if self.displayGlucosePreference.unit == .millimolesPerLiter {
++                            TextInput(label: "Upper limit", value: $viewModel.upperLimitChartMmol)
++                                .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
++                            TextInput(label: "Lower limit", value: $viewModel.lowerLimitChartMmol)
++                                .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
++                        } else {
++                            TextInput(label: "Upper limit", value: $viewModel.upperLimitChartMg)
++                                .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
++                            TextInput(label: "Lower limit", value: $viewModel.lowerLimitChartMg)
++                                .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
++                        }
++                    }
++                }
++                
++                Section {
++                    NavigationLink(
++                        destination: LiveActivityBottomRowManagerView(),
++                        label: { Text(NSLocalizedString("Bottom row configuration", comment: "Title for Bottom row configuration")) }
++                    )
++                }
++                
++                
++            }
++            .animation(.easeInOut, value: UUID())
++            .insetGroupedListStyle()
++            
++            Spacer()
++            Button(action: save) {
++                Text(NSLocalizedString("Save", comment: ""))
++            }
++            .buttonStyle(ActionButtonStyle())
++            .padding([.bottom, .horizontal])
++        }
++            .navigationBarTitle(Text(NSLocalizedString("Live activity", comment: "Live activity screen title")))
++    }
++    
++    @ViewBuilder
++    private func TextInput(label: String, value: Binding<Double>) -> some View {
++        HStack {
++            Text(NSLocalizedString(label, comment: "no comment"))
++            Spacer()
++            TextField("", value: value, format: .number)
++                .multilineTextAlignment(.trailing)
++            Text(self.displayGlucosePreference.unit.localizedShortUnitString)
++        }
++    }
++    
++    private func save() {
++        var settings = UserDefaults.standard.liveActivity ?? LiveActivitySettings()
++        settings.enabled = viewModel.enabled
++        settings.mode = viewModel.mode
++        settings.addPredictiveLine = viewModel.addPredictiveLine
++        settings.useLimits = viewModel.useLimits
++        settings.upperLimitChartMmol = viewModel.upperLimitChartMmol
++        settings.lowerLimitChartMmol = viewModel.lowerLimitChartMmol
++        settings.upperLimitChartMg = viewModel.upperLimitChartMg
++        settings.lowerLimitChartMg = viewModel.lowerLimitChartMg
++        
++        UserDefaults.standard.liveActivity = settings
++        NotificationCenter.default.post(name: .LiveActivitySettingsChanged, object: settings)
++    }
++}
+diff --git a/Loop/LoopCore/LiveActivitySettings.swift b/Loop/LoopCore/LiveActivitySettings.swift
+new file mode 100644
+index 00000000..71807464
+--- /dev/null
++++ b/Loop/LoopCore/LiveActivitySettings.swift
+@@ -0,0 +1,159 @@
++//
++//  LiveActivitySettings.swift
++//  LoopCore
++//
++//  Created by Bastiaan Verhaar on 04/07/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++
++public enum BottomRowConfiguration: Codable {
++    case iob
++    case cob
++    case basal
++    case currentBg
++    case eventualBg
++    case deltaBg
++    case loopCircle
++    case updatedAt
++    
++    static let defaults: [BottomRowConfiguration] =  [.currentBg, .iob, .cob, .updatedAt]
++    public static let all: [BottomRowConfiguration] = [.iob, .cob, .basal, .currentBg, .eventualBg, .deltaBg, .loopCircle, .updatedAt]
++    
++    public func name() -> String {
++        switch self {
++        case .iob:
++            return NSLocalizedString("IOB", comment: "")
++        case .cob:
++            return NSLocalizedString("COB", comment: "")
++        case .basal:
++            return NSLocalizedString("Basal", comment: "")
++        case .currentBg:
++            return NSLocalizedString("Current BG", comment: "")
++        case .eventualBg:
++            return NSLocalizedString("Event", comment: "")
++        case .deltaBg:
++            return NSLocalizedString("Delta", comment: "")
++        case .loopCircle:
++            return NSLocalizedString("Loop", comment: "")
++        case .updatedAt:
++            return NSLocalizedString("Updated", comment: "")
++        }
++    }
++    
++    public func description() -> String {
++        switch self {
++        case .iob:
++            return NSLocalizedString("Active Insulin", comment: "")
++        case .cob:
++            return NSLocalizedString("Active Carbohydrates", comment: "")
++        case .basal:
++            return NSLocalizedString("Basal", comment: "")
++        case .currentBg:
++            return NSLocalizedString("Current Glucose", comment: "")
++        case .eventualBg:
++            return NSLocalizedString("Eventually", comment: "")
++        case .deltaBg:
++            return NSLocalizedString("Delta", comment: "")
++        case .loopCircle:
++            return NSLocalizedString("Loop circle", comment: "")
++        case .updatedAt:
++            return NSLocalizedString("Updated at", comment: "")
++        }
++    }
++}
++
++public enum LiveActivityMode: Codable, CustomStringConvertible {
++    case large
++    case small
++    
++    public static let all: [LiveActivityMode] = [.large, .small]
++    public var description: String {
++        NSLocalizedString("In which mode do you want to render the Live Activity", comment: "")
++    }
++    
++    public func name() -> String {
++        switch self {
++        case .large:
++            return NSLocalizedString("Large", comment: "")
++        case .small:
++            return NSLocalizedString("Small", comment: "")
++        }
++    }
++}
++
++public struct LiveActivitySettings: Codable, Equatable {
++    public var enabled: Bool
++    public var mode: LiveActivityMode
++    public var addPredictiveLine: Bool
++    public var useLimits: Bool
++    public var upperLimitChartMmol: Double
++    public var lowerLimitChartMmol: Double
++    public var upperLimitChartMg: Double
++    public var lowerLimitChartMg: Double
++    public var bottomRowConfiguration: [BottomRowConfiguration]
++    
++    private enum CodingKeys: String, CodingKey {
++        case enabled
++        case mode
++        case addPredictiveLine
++        case bottomRowConfiguration
++        case useLimits
++        case upperLimitChartMmol
++        case lowerLimitChartMmol
++        case upperLimitChartMg
++        case lowerLimitChartMg
++    }
++    
++    private static let defaultUpperLimitMmol = Double(10)
++    private static let defaultLowerLimitMmol = Double(4)
++    private static let defaultUpperLimitMg = Double(180)
++    private static let defaultLowerLimitMg = Double(72)
++    
++    public init(from decoder:Decoder) throws {
++        let values = try decoder.container(keyedBy: CodingKeys.self)
++
++        self.enabled = try values.decode(Bool.self, forKey: .enabled)
++        self.mode = try values.decodeIfPresent(LiveActivityMode.self, forKey: .mode) ?? .large
++        self.addPredictiveLine = try values.decode(Bool.self, forKey: .addPredictiveLine)
++        self.useLimits = try values.decodeIfPresent(Bool.self, forKey: .useLimits) ?? true
++        self.upperLimitChartMmol = try values.decode(Double?.self, forKey: .upperLimitChartMmol) ?? LiveActivitySettings.defaultUpperLimitMmol
++        self.lowerLimitChartMmol = try values.decode(Double?.self, forKey: .lowerLimitChartMmol) ?? LiveActivitySettings.defaultLowerLimitMmol
++        self.upperLimitChartMg = try values.decode(Double?.self, forKey: .upperLimitChartMg) ?? LiveActivitySettings.defaultUpperLimitMg
++        self.lowerLimitChartMg = try values.decode(Double?.self, forKey: .lowerLimitChartMg) ?? LiveActivitySettings.defaultLowerLimitMg
++        self.bottomRowConfiguration = try values.decode([BottomRowConfiguration].self, forKey: .bottomRowConfiguration)
++    }
++    
++    public init() {
++        self.enabled = true
++        self.mode = .large
++        self.addPredictiveLine = true
++        self.useLimits = true
++        self.upperLimitChartMmol = LiveActivitySettings.defaultUpperLimitMmol
++        self.lowerLimitChartMmol = LiveActivitySettings.defaultLowerLimitMmol
++        self.upperLimitChartMg = LiveActivitySettings.defaultUpperLimitMg
++        self.lowerLimitChartMg = LiveActivitySettings.defaultLowerLimitMg
++        self.bottomRowConfiguration = BottomRowConfiguration.defaults
++    }
++    
++    public static func == (lhs: LiveActivitySettings, rhs: LiveActivitySettings) -> Bool {
++        return lhs.addPredictiveLine == rhs.addPredictiveLine &&
++            lhs.mode == rhs.mode &&
++            lhs.useLimits == rhs.useLimits &&
++            lhs.lowerLimitChartMmol == rhs.lowerLimitChartMmol &&
++            lhs.upperLimitChartMmol == rhs.upperLimitChartMmol &&
++            lhs.lowerLimitChartMg == rhs.lowerLimitChartMg &&
++            lhs.upperLimitChartMg == rhs.upperLimitChartMg
++    }
++    
++    public static func != (lhs: LiveActivitySettings, rhs: LiveActivitySettings) -> Bool {
++        return lhs.addPredictiveLine != rhs.addPredictiveLine ||
++            lhs.mode != rhs.mode ||
++            lhs.useLimits != rhs.useLimits ||
++            lhs.lowerLimitChartMmol != rhs.lowerLimitChartMmol ||
++            lhs.upperLimitChartMmol != rhs.upperLimitChartMmol ||
++            lhs.lowerLimitChartMg != rhs.lowerLimitChartMg ||
++            lhs.upperLimitChartMg != rhs.upperLimitChartMg
++    }
++}
+\ No newline at end of file
+diff --git a/Loop/LoopCore/NSUserDefaults.swift b/Loop/LoopCore/NSUserDefaults.swift
+index 93fa7e17..dacf2ecd 100644
+--- a/Loop/LoopCore/NSUserDefaults.swift
++++ b/Loop/LoopCore/NSUserDefaults.swift
+@@ -23,6 +23,7 @@ extension UserDefaults {
+         case allowSimulators = "com.loopkit.Loop.allowSimulators"
+         case LastMissedMealNotification = "com.loopkit.Loop.lastMissedMealNotification"
+         case userRequestedLoopReset = "com.loopkit.Loop.userRequestedLoopReset"
++        case liveActivity = "com.loopkit.Loop.liveActivity"
+     }
+ 
+     public static let appGroup = UserDefaults(suiteName: Bundle.main.appGroupSuiteName)
+@@ -165,6 +166,29 @@ extension UserDefaults {
+             setValue(newValue, forKey: Key.userRequestedLoopReset.rawValue)
+         }
+     }
++    
++    public var liveActivity: LiveActivitySettings? {
++        get {
++            let decoder = JSONDecoder()
++            guard let data = object(forKey: Key.liveActivity.rawValue) as? Data else {
++                return nil
++            }
++            return try? decoder.decode(LiveActivitySettings.self, from: data)
++        }
++        set {
++            do {
++                if let newValue = newValue {
++                    let encoder = JSONEncoder()
++                    let data = try encoder.encode(newValue)
++                    set(data, forKey: Key.liveActivity.rawValue)
++                } else {
++                    set(nil, forKey: Key.liveActivity.rawValue)
++                }
++            } catch {
++                assertionFailure("Unable to encode MissedMealNotification")
++            }
++        }
++    }
+ 
+     public func removeLegacyLoopSettings() {
+         removeObject(forKey: "com.loudnate.Naterade.BasalRateSchedule")

--- a/negative_insulin/dev377_negative_insulin_live_activity.patch
+++ b/negative_insulin/dev377_negative_insulin_live_activity.patch
@@ -1,0 +1,991 @@
+Submodule Loop e80e515...3645d8c:
+diff --git a/Loop/Loop.xcodeproj/project.pbxproj b/Loop/Loop.xcodeproj/project.pbxproj
+index 15966e4b..7e00af68 100644
+--- a/Loop/Loop.xcodeproj/project.pbxproj
++++ b/Loop/Loop.xcodeproj/project.pbxproj
+@@ -7,6 +7,7 @@
+ 	objects = {
+ 
+ /* Begin PBXBuildFile section */
++		120490CB2CBFB25A006BDF0A /* NegativeInsulinDamperSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120490CA2CBFB25A006BDF0A /* NegativeInsulinDamperSelectionView.swift */; };
+ 		1419606428D9550400BA86E0 /* LoopKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 437AFEE6203688CF008C4892 /* LoopKitUI.framework */; };
+ 		1419606928D9554E00BA86E0 /* LoopKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 437AFEE6203688CF008C4892 /* LoopKitUI.framework */; };
+ 		1419606A28D955BC00BA86E0 /* MockKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C101947127DD473C004E7EB8 /* MockKitUI.framework */; };
+@@ -401,8 +402,6 @@
+ 		B4E96D5D248A82A2002DABAD /* StatusBarHUDView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B4E96D5C248A82A2002DABAD /* StatusBarHUDView.xib */; };
+ 		B4F3D25124AF890C0095CE44 /* BluetoothStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F3D25024AF890C0095CE44 /* BluetoothStateManager.swift */; };
+ 		B4FEEF7D24B8A71F00A8DF9B /* DeviceDataManager+DeviceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FEEF7C24B8A71F00A8DF9B /* DeviceDataManager+DeviceStatus.swift */; };
+-		B813C5682C9C30B400306DAF /* QuickStatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B813C5672C9C30B400306DAF /* QuickStatsViewModel.swift */; };
+-		B813C56C2C9C30DC00306DAF /* QuickStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B813C56B2C9C30DC00306DAF /* QuickStatsView.swift */; };
+ 		B82181F62C93628300478A91 /* LiveActivityManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82181F52C93628300478A91 /* LiveActivityManagementViewModel.swift */; };
+ 		B82182002C93716A00478A91 /* ChartAxisGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82181F92C936AD600478A91 /* ChartAxisGenerator.swift */; };
+ 		B851FFC52C37221800D738C1 /* LiveActivityManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B851FFC42C37221800D738C1 /* LiveActivityManagementView.swift */; };
+@@ -414,7 +413,7 @@
+ 		B87539CF2C2DCB770085A975 /* BasalViewActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87539CE2C2DCB770085A975 /* BasalViewActivity.swift */; };
+ 		B87D411D2C28A69600120877 /* GlucoseLiveActivityConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87D411C2C28A69600120877 /* GlucoseLiveActivityConfiguration.swift */; };
+ 		B87D411F2C28A85F00120877 /* ActivityKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B87D411E2C28A85F00120877 /* ActivityKit.framework */; };
+-		B8A937B82C29BA5900E38645 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A937B72C29BA5900E38645 /* LiveActivityManager.swift */; };
++		B8A937B82C29BA5900E38645 /* GlucoseActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A937B72C29BA5900E38645 /* GlucoseActivityManager.swift */; };
+ 		B8A937C32C29C3B400E38645 /* GlucoseActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A937C02C29C29300E38645 /* GlucoseActivityAttributes.swift */; };
+ 		B8A937C42C29C43B00E38645 /* GlucoseActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A937C02C29C29300E38645 /* GlucoseActivityAttributes.swift */; };
+ 		B8FD0B522C39CA3E003FB72B /* LiveActivityBottomRowManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FD0B512C39CA3E003FB72B /* LiveActivityBottomRowManagerView.swift */; };
+@@ -770,6 +769,7 @@
+ /* End PBXCopyFilesBuildPhase section */
+ 
+ /* Begin PBXFileReference section */
++		120490CA2CBFB25A006BDF0A /* NegativeInsulinDamperSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NegativeInsulinDamperSelectionView.swift; sourceTree = "<group>"; };
+ 		142CB7582A60BF2E0075748A /* EditMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditMode.swift; sourceTree = "<group>"; };
+ 		142CB75A2A60BFC30075748A /* FavoriteFoodsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoriteFoodsView.swift; sourceTree = "<group>"; };
+ 		1452F4A82A851C9400F8B9E4 /* AddEditFavoriteFoodViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditFavoriteFoodViewModel.swift; sourceTree = "<group>"; };
+@@ -1352,8 +1352,6 @@
+ 		B4E96D5C248A82A2002DABAD /* StatusBarHUDView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatusBarHUDView.xib; sourceTree = "<group>"; };
+ 		B4F3D25024AF890C0095CE44 /* BluetoothStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothStateManager.swift; sourceTree = "<group>"; };
+ 		B4FEEF7C24B8A71F00A8DF9B /* DeviceDataManager+DeviceStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeviceDataManager+DeviceStatus.swift"; sourceTree = "<group>"; };
+-		B813C5672C9C30B400306DAF /* QuickStatsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStatsViewModel.swift; sourceTree = "<group>"; };
+-		B813C56B2C9C30DC00306DAF /* QuickStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStatsView.swift; sourceTree = "<group>"; };
+ 		B82181F52C93628300478A91 /* LiveActivityManagementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManagementViewModel.swift; sourceTree = "<group>"; };
+ 		B82181F92C936AD600478A91 /* ChartAxisGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartAxisGenerator.swift; sourceTree = "<group>"; };
+ 		B851FFC42C37221800D738C1 /* LiveActivityManagementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManagementView.swift; sourceTree = "<group>"; };
+@@ -1218,7 +1216,7 @@
+ 		B87539CE2C2DCB770085A975 /* BasalViewActivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasalViewActivity.swift; sourceTree = "<group>"; };
+ 		B87D411C2C28A69600120877 /* GlucoseLiveActivityConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseLiveActivityConfiguration.swift; sourceTree = "<group>"; };
+ 		B87D411E2C28A85F00120877 /* ActivityKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ActivityKit.framework; path = System/Library/Frameworks/ActivityKit.framework; sourceTree = SDKROOT; };
+-		B8A937B72C29BA5900E38645 /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
++		B8A937B72C29BA5900E38645 /* GlucoseActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseActivityManager.swift; sourceTree = "<group>"; };
+ 		B8A937C02C29C29300E38645 /* GlucoseActivityAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlucoseActivityAttributes.swift; sourceTree = "<group>"; };
+ 		B8FD0B512C39CA3E003FB72B /* LiveActivityBottomRowManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityBottomRowManagerView.swift; sourceTree = "<group>"; };
+ 		B66D1F202E6A5D6500471149 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+@@ -2323,6 +2321,7 @@
+ 				DD3DBD282A33AFE9000F8B5B /* IntegralRetrospectiveCorrectionSelectionView.swift */,
+ 				B851FFC42C37221800D738C1 /* LiveActivityManagementView.swift */,
+ 				B8FD0B512C39CA3E003FB72B /* LiveActivityBottomRowManagerView.swift */,
++				120490CA2CBFB25A006BDF0A /* NegativeInsulinDamperSelectionView.swift */,
+ 			);
+ 			path = Views;
+ 			sourceTree = "<group>";
+@@ -2825,7 +2824,7 @@
+ 		B8A937C52C29C44600E38645 /* Live Activity */ = {
+ 			isa = PBXGroup;
+ 			children = (
+-				B8A937B72C29BA5900E38645 /* LiveActivityManager.swift */,
++				B8A937B72C29BA5900E38645 /* GlucoseActivityManager.swift */,
+ 				B8A937C02C29C29300E38645 /* GlucoseActivityAttributes.swift */,
+ 				B82181F92C936AD600478A91 /* ChartAxisGenerator.swift */,
+ 			);
+@@ -3902,7 +3901,7 @@
+ 				A97F250825E056D500F0EE19 /* OnboardingManager.swift in Sources */,
+ 				438D42F91D7C88BC003244B0 /* PredictionInputEffect.swift in Sources */,
+ 				892A5D692230C41D008961AB /* RangeReplaceableCollection.swift in Sources */,
+-				B8A937B82C29BA5900E38645 /* LiveActivityManager.swift in Sources */,
++				B8A937B82C29BA5900E38645 /* GlucoseActivityManager.swift in Sources */,
+ 				DDC389F62A2B61750066E2E8 /* ApplicationFactorStrategy.swift in Sources */,
+ 				4F70C2101DE8FAC5006380B7 /* ExtensionDataManager.swift in Sources */,
+ 				43DFB62320D4CAE7008A7BAE /* PumpManager.swift in Sources */,
+@@ -3918,6 +3917,7 @@
+ 				895FE0952201234000FCF18A /* OverrideSelectionViewController.swift in Sources */,
+ 				C1EF747228D6A44A00C8C083 /* CrashRecoveryManager.swift in Sources */,
+ 				A9F66FC3247F451500096EA7 /* UIDevice+Loop.swift in Sources */,
++				120490CB2CBFB25A006BDF0A /* NegativeInsulinDamperSelectionView.swift in Sources */,
+ 				439706E622D2E84900C81566 /* PredictionSettingTableViewCell.swift in Sources */,
+ 				430D85891F44037000AF2D4F /* HUDViewTableViewCell.swift in Sources */,
+ 				43A51E211EB6DBDD000736CC /* LoopChartsTableViewController.swift in Sources */,
+diff --git a/Loop/Loop/Managers/Live Activity/LiveActivityManager.swift b/Loop/Loop/Managers/Live Activity/GlucoseActivityManager.swift
+index 30c6920f..3903ee8b 100644
+--- a/Loop/Loop/Managers/Live Activity/LiveActivityManager.swift	
++++ b/Loop/Loop/Managers/Live Activity/GlucoseActivityManager.swift	
+@@ -18,7 +18,7 @@ extension Notification.Name {
+ }
+ 
+ @available(iOS 16.2, *)
+-class LiveActivityManager {
++class GlucoseActivityManager {
+     private let activityInfo = ActivityAuthorizationInfo()
+     private var activity: Activity<GlucoseActivityAttributes>?
+     private let healthStore = HKHealthStore()
+@@ -89,7 +89,10 @@ class LiveActivityManager {
+         Task {
+             if self.needsRecreation(), await UIApplication.shared.applicationState == .active {
+                 // activity is no longer visible or old. End it and try to push the update again
++                print("INFO: Live Activities needs recreation")
+                 await endActivity()
++                update()
++                return
+             }
+             
+             guard let unit = await self.healthStore.cachedPreferredUnits(for: .bloodGlucose) else {
+@@ -97,7 +100,6 @@ class LiveActivityManager {
+                 return
+             }
+             
+-            let isMmol = unit == HKUnit.millimolesPerLiter
+             await self.endUnknownActivities()
+ 
+             let statusContext = UserDefaults.appGroup?.statusExtensionContext
+@@ -108,7 +110,7 @@ class LiveActivityManager {
+                 print("ERROR: No glucose sample found...")
+                 return
+             }
+-
++            
+             let current = currentGlucose.quantity.doubleValue(for: unit)
+             
+             var delta: String = "+\(glucoseFormatter.string(from: Double(0)) ?? "")"
+@@ -118,13 +120,14 @@ class LiveActivityManager {
+                 delta = "\(deltaValue < 0 ? "-" : "+")\(glucoseFormatter.string(from: abs(deltaValue)) ?? "??")"
+             }
+             
++            
+             let bottomRow = self.getBottomRow(
+                 currentGlucose: current,
+                 delta: delta,
+                 statusContext: statusContext,
+                 glucoseFormatter: glucoseFormatter
+             )
+-
++            
+             var predicatedGlucose: [Double] = []
+             if let samples = statusContext?.predictedGlucose?.values, settings.addPredictiveLine {
+                 predicatedGlucose = samples
+@@ -177,7 +180,7 @@ class LiveActivityManager {
+                 currentGlucose: current,
+                 trendType: statusContext?.glucoseDisplay?.trendType,
+                 delta: delta,
+-                isMmol: isMmol,
++                isMmol: unit == HKUnit.millimolesPerLiter,
+                 isCloseLoop: statusContext?.isClosedLoop ?? false,
+                 lastCompleted: statusContext?.lastLoopCompleted,
+                 bottomRow: bottomRow,
+@@ -255,6 +258,7 @@ class LiveActivityManager {
+     
+     private func endActivity() async {
+         let dynamicState = self.activity?.content.state
++        
+         await self.activity?.end(nil, dismissalPolicy: .immediate)
+         for unknownActivity in Activity<GlucoseActivityAttributes>.activities {
+             await unknownActivity.end(nil, dismissalPolicy: .immediate)
+diff --git a/Loop/Loop/Managers/LoopDataManager.swift b/Loop/Loop/Managers/LoopDataManager.swift
+index 36c228c7..5aa9c4fd 100644
+--- a/Loop/Loop/Managers/LoopDataManager.swift
++++ b/Loop/Loop/Managers/LoopDataManager.swift
+@@ -69,7 +69,7 @@ final class LoopDataManager {
+ 
+     private var insulinOnBoard: InsulinValue?
+     
+-    private var liveActivityManager: LiveActivityManager?
++    private var liveActivityManager: GlucoseActivityManager?
+ 
+     deinit {
+         for observer in notificationObservers {
+@@ -127,7 +127,7 @@ final class LoopDataManager {
+ 
+         self.trustedTimeOffset = trustedTimeOffset
+         
+-        self.liveActivityManager = LiveActivityManager(
++        self.liveActivityManager = GlucoseActivityManager(
+             glucoseStore: self.glucoseStore,
+             doseStore: self.doseStore,
+             loopSettings: self.settings
+@@ -375,6 +375,13 @@ final class LoopDataManager {
+             predictedGlucose = nil
+         }
+     }
++    
++    private var negativeInsulinDamper: Double? {
++        didSet {
++            predictedGlucose = nil
++        }
++    }
++    private var negativeInsulinDamperCachedBaseDate: Date = .distantPast
+ 
+     /// When combining retrospective glucose discrepancies, extend the window slightly as a buffer.
+     private let retrospectiveCorrectionGroupingIntervalMultiplier = 1.01
+@@ -471,6 +478,7 @@ final class LoopDataManager {
+         insulinEffect = nil
+         insulinEffectIncludingPendingInsulin = nil
+         predictedGlucose = nil
++        negativeInsulinDamper = nil
+     }
+ 
+     // MARK: - Background task management
+@@ -1013,5 +1021,63 @@ extension LoopDataManager {
+         let nextCounteractionEffectDate = insulinCounteractionEffects.last?.endDate ?? earliestEffectDate
+         let insulinEffectStartDate = nextCounteractionEffectDate.addingTimeInterval(.minutes(-5))
++        
++        if negativeInsulinDamper == nil || nextCounteractionEffectDate != negativeInsulinDamperCachedBaseDate {
++            self.logger.debug("Recomputing negative insulin damper")
++            updateGroup.enter()
++            let lastDoseStartDate = nextCounteractionEffectDate.addingTimeInterval(.minutes(-15))
++            doseStore.getGlucoseEffects(start: insulinEffectStartDate, end: nil, doseEnd: lastDoseStartDate, basalDosingEnd: lastDoseStartDate) { (result) -> Void in
++                switch result {
++                case .failure(let error):
++                    self.logger.error("Could not fetch insulin effects for damper: %{public}@", error.localizedDescription)
++                    self.negativeInsulinDamper = nil
++                    self.negativeInsulinDamperCachedBaseDate = .distantPast
++                    warnings.append(.fetchDataWarning(.negativeInsulinDamper(error: error)))
++                case .success(let effects):
++                    var posDeltaSum = 0.0
++                    effects.enumerated().forEach{
++                        if $0.offset > 0 {
++                            let delta = $0.element.quantity.doubleValue(for: .milligramsPerDeciliter) - effects[$0.offset - 1].quantity.doubleValue(for: .milligramsPerDeciliter)
++                            posDeltaSum += max(0, delta)
++                        }
++                    }
++                    
++                    guard let insulinSensitivity = latestSettings.insulinSensitivitySchedule?.quantity(at: lastGlucoseDate),                    let basalRate = latestSettings.basalRateSchedule?.value(at: lastGlucoseDate) else {
++                        
++                        self.logger.error("Could not fetch ISF and/or basal rates for damper")
++                        self.negativeInsulinDamper = nil
++                        self.negativeInsulinDamperCachedBaseDate = .distantPast
++
++                        break
++                    }
++                    let model = self.doseStore.insulinModelProvider.model(for: self.pumpInsulinType)
++                    
++                    // anchorScale is set to 1 hour for rapid acting adult, and 44 minutes for ultra-rapid insulins
++                    let anchorScale: Double
++                    if let expModel = model as? ExponentialInsulinModel {
++                        anchorScale = 0.8 * expModel.peakActivityTime.hours
++                    } else {
++                        anchorScale = 1.0
++                    }
++                    
++                    // NID will change the final prediction so that positive changes will be multiplied by weight alpha
++                    // the long term slope will be marginalSlope
++                    // in the initial linear scaling region alpha will be anchorAlpha at anchorPoint
++                    // note that anchorPoint is unaffected by overrides (the changes cancel out)
++                    let marginalSlope = 0.05
++                    let anchorPoint = anchorScale * basalRate * insulinSensitivity.doubleValue(for: .milligramsPerDeciliter)
++                    let anchorAlpha = 0.75
++                    
++                    let alpha = LoopDataManager.calculateNegativeInsulinDamperAlpha(anchorAlpha, anchorPoint, marginalSlope, posDeltaSum)
++
++                    // alpha should never be less than marginalSlope
++                    self.negativeInsulinDamper = max(0, 1 - max(marginalSlope, alpha))
++                    self.negativeInsulinDamperCachedBaseDate = nextCounteractionEffectDate
++                }
++
++                updateGroup.leave()
++            }
++
++        }
+ 
+         if glucoseMomentumEffect == nil {
+             updateGroup.enter()
+@@ -1031,7 +1097,8 @@ extension LoopDataManager {
+         if insulinEffect == nil || insulinEffect?.first?.startDate ?? .distantFuture > insulinEffectStartDate {
+             self.logger.debug("Recomputing insulin effects")
+             updateGroup.enter()
+-            doseStore.getGlucoseEffects(start: insulinEffectStartDate, end: nil, basalDosingEnd: now()) { (result) -> Void in
++            let basalDosingEnd = now()
++            doseStore.getGlucoseEffects(start: insulinEffectStartDate, end: nil, doseEnd: nil, basalDosingEnd: basalDosingEnd) { (result) -> Void in
+                 switch result {
+                 case .failure(let error):
+                     self.logger.error("Could not fetch insulin effects: %{public}@", error.localizedDescription)
+@@ -1047,7 +1114,7 @@ extension LoopDataManager {
+ 
+         if insulinEffectIncludingPendingInsulin == nil {
+             updateGroup.enter()
+-            doseStore.getGlucoseEffects(start: insulinEffectStartDate, end: nil, basalDosingEnd: nil) { (result) -> Void in
++            doseStore.getGlucoseEffects(start: insulinEffectStartDate, end: nil, doseEnd: nil, basalDosingEnd: nil) { (result) -> Void in
+                 switch result {
+                 case .failure(let error):
+                     self.logger.error("Could not fetch insulin effects including pending insulin: %{public}@", error.localizedDescription)
+@@ -1175,6 +1242,21 @@ extension LoopDataManager {
+ 
+         return updatePredictedGlucoseAndRecommendedDose(with: dosingDecision)
+     }
++    
++    static func calculateNegativeInsulinDamperAlpha(_ anchorAlpha: Double, _ anchorPoint: Double, _ marginalSlope: Double, _ posDeltaSum: Double) -> Double {
++        let linearScaleSlope = (1.0 - anchorAlpha)/anchorPoint // how alpha scales down in the linear scale region
++        
++        // the slope in the linear scale region of alpha * posDeltaSum is 1 - 2*linearScaleSlope*posDeltaSum.
++        // the transitionPoint is where we transition from linear scale region to marginalSlope. The slope is continuous at this point
++        let transitionPoint = (1 - marginalSlope) / (2 * linearScaleSlope)
++        
++        if posDeltaSum < transitionPoint { // linear scaling region
++            return 1 - linearScaleSlope * posDeltaSum
++        } else { // marginal slope region
++            let transitionValue = (1 - linearScaleSlope * transitionPoint) * transitionPoint
++            return (transitionValue + marginalSlope * (posDeltaSum - transitionPoint)) / posDeltaSum
++        }
++    }
+ 
+     private func notify(forChange context: LoopUpdateContext) {
+         NotificationCenter.default.post(name: .LoopDataUpdated,
+@@ -1216,7 +1298,7 @@ extension LoopDataManager {
+         // All outstanding potential insulin delivery
+         return pendingTempBasalInsulin + pendingBolusAmount
+     }
+-
++    
+     /// - Throws:
+     ///     - LoopError.missingDataError
+     ///     - LoopError.configurationError
+@@ -1354,6 +1436,51 @@ extension LoopDataManager {
+         }
+ 
+         var prediction = LoopMath.predictGlucose(startingAt: glucose, momentum: momentum, effects: effects)
++        
++        if inputs.contains(.damper), let damper = negativeInsulinDamper {
++            let damperOnly = inputs.isSubset(of: [.damper])
++            if damperOnly {
++                prediction = try predictGlucose(
++                    startingAt: startingGlucoseOverride,
++                    using: settings.enabledEffects.subtracting(.damper),
++                    historicalInsulinEffect: insulinEffectOverride,
++                    insulinCounteractionEffects: insulinCounteractionEffectsOverride,
++                    historicalCarbEffect: carbEffectOverride,
++                    potentialBolus: potentialBolus,
++                    potentialCarbEntry: potentialCarbEntry,
++                    replacingCarbEntry: replacedCarbEntry,
++                    includingPendingInsulin: includingPendingInsulin,
++                    includingPositiveVelocityAndRC: includingPositiveVelocityAndRC)
++            }
++             
++            let alpha = 1 - damper
++            var dampedPrediction = [PredictedGlucoseValue]()
++            var value = 0.0
++            prediction.enumerated().forEach{
++                
++                if $0.offset == 0 {
++                    value = $0.element.quantity.doubleValue(for: .milligramsPerDeciliter)
++                    dampedPrediction.append($0.element)
++                    return
++                }
++                let delta = $0.element.quantity.doubleValue(for: .milligramsPerDeciliter) - prediction[$0.offset - 1].quantity.doubleValue(for: .milligramsPerDeciliter)
++
++                if damperOnly {
++                    // we just want to display the effects of damper relative to everything else
++                    if delta > 0 {
++                        value -= damper * delta
++                    }
++                } else if delta > 0 {
++                    value += alpha * delta
++                } else {
++                    value += delta
++                }
++                dampedPrediction.append(PredictedGlucoseValue(startDate: $0.element.startDate, quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: value)))
++            }
++            
++            prediction = dampedPrediction
++        }
++
+ 
+         // Dosing requires prediction entries at least as long as the insulin model duration.
+         // If our prediction is shorter than that, then extend it here.
+@@ -1384,7 +1511,7 @@ extension LoopDataManager {
+         var insulinEffect: [GlucoseEffect]?
+         let basalDosingEnd = includingPendingInsulin ? nil : now()
+         updateGroup.enter()
+-        doseStore.getGlucoseEffects(start: insulinEffectStartDate, end: nil, basalDosingEnd: basalDosingEnd) { result in
++        doseStore.getGlucoseEffects(start: insulinEffectStartDate, end: nil, doseEnd: nil, basalDosingEnd: basalDosingEnd) { result in
+             switch result {
+             case .failure(let error):
+                 effectCalculationError.mutate { $0 = error }
+@@ -1972,6 +2099,9 @@ protocol LoopState {
+ 
+     /// The total corrective glucose effect from retrospective correction
+     var totalRetrospectiveCorrection: HKQuantity? { get }
++    
++    /// The negative insulin damper - if present then is in the range [0,1]
++    var negativeInsulinDamper: Double? { get}
+ 
+     /// Calculates a new prediction from the current data using the specified effect inputs
+     ///
+@@ -2096,6 +2226,11 @@ extension LoopDataManager {
+             dispatchPrecondition(condition: .onQueue(loopDataManager.dataAccessQueue))
+             return loopDataManager.retrospectiveCorrection.totalGlucoseCorrectionEffect
+         }
++        
++        var negativeInsulinDamper: Double? {
++            dispatchPrecondition(condition: .onQueue(loopDataManager.dataAccessQueue))
++            return loopDataManager.negativeInsulinDamper
++        }
+ 
+         func predictGlucose(using inputs: PredictionInputEffect, potentialBolus: DoseEntry?, potentialCarbEntry: NewCarbEntry?, replacingCarbEntry replacedCarbEntry: StoredCarbEntry?, includingPendingInsulin: Bool, considerPositiveVelocityAndRC: Bool) throws -> [PredictedGlucoseValue] {
+             dispatchPrecondition(condition: .onQueue(loopDataManager.dataAccessQueue))
+diff --git a/Loop/Loop/Managers/Store Protocols/DoseStoreProtocol.swift b/Loop/Loop/Managers/Store Protocols/DoseStoreProtocol.swift
+index dd21ea2a..2887d14c 100644
+--- a/Loop/Loop/Managers/Store Protocols/DoseStoreProtocol.swift	
++++ b/Loop/Loop/Managers/Store Protocols/DoseStoreProtocol.swift	
+@@ -50,7 +50,7 @@ protocol DoseStoreProtocol: AnyObject {
+     // MARK: IOB and insulin effect
+     func insulinOnBoard(at date: Date, completion: @escaping (_ result: DoseStoreResult<InsulinValue>) -> Void)
+     
+-    func getGlucoseEffects(start: Date, end: Date?, basalDosingEnd: Date?, completion: @escaping (_ result: DoseStoreResult<[GlucoseEffect]>) -> Void)
++    func getGlucoseEffects(start: Date, end: Date?, doseEnd: Date?, basalDosingEnd: Date?, completion: @escaping (_ result: DoseStoreResult<[GlucoseEffect]>) -> Void)
+     
+     func getInsulinOnBoardValues(start: Date, end: Date? , basalDosingEnd: Date?, completion: @escaping (_ result: DoseStoreResult<[InsulinValue]>) -> Void)
+     
+diff --git a/Loop/Loop/Models/LoopSettings+Loop.swift b/Loop/Loop/Models/LoopSettings+Loop.swift
+index e4952934..ba296f1d 100644
+--- a/Loop/Loop/Models/LoopSettings+Loop.swift
++++ b/Loop/Loop/Models/LoopSettings+Loop.swift
+@@ -15,6 +15,9 @@ extension LoopSettings {
+         if !LoopConstants.retrospectiveCorrectionEnabled {
+             inputs.remove(.retrospection)
+         }
++        if !UserDefaults.standard.negativeInsulinDamperEnabled {
++            inputs.remove(.damper)
++        }
+         return inputs
+     }    
+ }
+diff --git a/Loop/Loop/Models/LoopWarning.swift b/Loop/Loop/Models/LoopWarning.swift
+index 45439b3c..d43a7d80 100644
+--- a/Loop/Loop/Models/LoopWarning.swift
++++ b/Loop/Loop/Models/LoopWarning.swift
+@@ -14,6 +14,7 @@ enum FetchDataWarningDetail {
+     case glucoseMomentumEffect(error: Error)
+     case insulinEffect(error: Error)
+     case insulinEffectIncludingPendingInsulin(error: Error)
++    case negativeInsulinDamper(error: Error)
+     case insulinCounteractionEffect(error: Error)
+     case carbEffect(error: Error)
+     case carbsOnBoard(error: Error)
+@@ -32,6 +33,8 @@ extension FetchDataWarningDetail {
+             return "insulinEffect"
+         case .insulinEffectIncludingPendingInsulin:
+             return "insulinEffectIncludingPendingInsulin"
++        case .negativeInsulinDamper:
++            return "negativeInsulinDamper"
+         case .insulinCounteractionEffect:
+             return "insulinCounteractionEffect"
+         case .carbEffect:
+@@ -53,6 +56,7 @@ extension FetchDataWarningDetail {
+              .insulinEffect(let error),
+              .insulinEffectIncludingPendingInsulin(let error),
+              .insulinCounteractionEffect(let error),
++             .negativeInsulinDamper(let error),
+              .carbEffect(let error),
+              .carbsOnBoard(let error),
+              .insulinOnBoard(let error),
+diff --git a/Loop/Loop/Models/PredictionInputEffect.swift b/Loop/Loop/Models/PredictionInputEffect.swift
+index 45fb5ea0..c80cde1d 100644
+--- a/Loop/Loop/Models/PredictionInputEffect.swift
++++ b/Loop/Loop/Models/PredictionInputEffect.swift
+@@ -18,8 +18,9 @@ struct PredictionInputEffect: OptionSet {
+     static let momentum         = PredictionInputEffect(rawValue: 1 << 2)
+     static let retrospection    = PredictionInputEffect(rawValue: 1 << 3)
+     static let suspend          = PredictionInputEffect(rawValue: 1 << 4)
++    static let damper           = PredictionInputEffect(rawValue: 1 << 5)
+ 
+-    static let all: PredictionInputEffect = [.carbs, .insulin, .momentum, .retrospection]
++    static let all: PredictionInputEffect = [.carbs, .insulin, .damper, .momentum, .retrospection]
+ 
+     var localizedTitle: String? {
+         switch self {
+@@ -27,6 +28,8 @@ struct PredictionInputEffect: OptionSet {
+             return NSLocalizedString("Carbohydrates", comment: "Title of the prediction input effect for carbohydrates")
+         case [.insulin]:
+             return NSLocalizedString("Insulin", comment: "Title of the prediction input effect for insulin")
++        case [.damper]:
++            return NSLocalizedString("Negative Insulin Damper", comment: "Title of the prediction input effect for negative insulin damper")
+         case [.momentum]:
+             return NSLocalizedString("Glucose Momentum", comment: "Title of the prediction input effect for glucose momentum")
+         case [.retrospection]:
+@@ -44,6 +47,8 @@ struct PredictionInputEffect: OptionSet {
+             return String(format: NSLocalizedString("Carbs Absorbed (g) ÷ Carb Ratio (g/U) × Insulin Sensitivity (%1$@/U)", comment: "Description of the prediction input effect for carbohydrates. (1: The glucose unit string)"), unit.localizedShortUnitString)
+         case [.insulin]:
+             return String(format: NSLocalizedString("Insulin Absorbed (U) × Insulin Sensitivity (%1$@/U)", comment: "Description of the prediction input effect for insulin"), unit.localizedShortUnitString)
++        case [.damper]:
++            return String(format: NSLocalizedString("Reduces increases in glucose. The damper is stronger when there is more negative insulin", comment: "Description of the prediction input effect for negative insulin damper"), unit.localizedShortUnitString)
+         case [.momentum]:
+             return NSLocalizedString("15 min glucose regression coefficient (b₁), continued with decay over 30 min", comment: "Description of the prediction input effect for glucose momentum")
+         case [.retrospection]:
+diff --git a/Loop/Loop/View Controllers/PredictionTableViewController.swift b/Loop/Loop/View Controllers/PredictionTableViewController.swift
+index a460e52a..fc477e7e 100644
+--- a/Loop/Loop/View Controllers/PredictionTableViewController.swift	
++++ b/Loop/Loop/View Controllers/PredictionTableViewController.swift	
+@@ -71,6 +71,8 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
+     private var retrospectiveGlucoseDiscrepancies: [GlucoseChange]?
+ 
+     private var totalRetrospectiveCorrection: HKQuantity?
++    
++    private var negativeInsulinDamper: Double?
+ 
+     private var refreshContext = RefreshContext.all
+ 
+@@ -111,6 +113,7 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
+         let reloadGroup = DispatchGroup()
+         var glucoseSamples: [StoredGlucoseSample]?
+         var totalRetrospectiveCorrection: HKQuantity?
++        var negativeInsulinDamper: Double?
+ 
+         if self.refreshContext.remove(.glucose) != nil {
+             reloadGroup.enter()
+@@ -132,6 +135,7 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
+         deviceManager.loopManager.getLoopState { (manager, state) in
+             self.retrospectiveGlucoseDiscrepancies = state.retrospectiveGlucoseDiscrepancies
+             totalRetrospectiveCorrection = state.totalRetrospectiveCorrection
++            negativeInsulinDamper = state.negativeInsulinDamper
+             self.glucoseChart.setPredictedGlucoseValues(state.predictedGlucoseIncludingPendingInsulin ?? [])
+ 
+             do {
+@@ -164,6 +168,9 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
+             if let totalRetrospectiveCorrection = totalRetrospectiveCorrection {
+                 self.totalRetrospectiveCorrection = totalRetrospectiveCorrection
+             }
++            if let negativeInsulinDamper = negativeInsulinDamper {
++                self.negativeInsulinDamper = negativeInsulinDamper
++            }
+ 
+             self.charts.prerender()
+ 
+@@ -197,9 +204,16 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
+ 
+     private var eventualGlucoseDescription: String?
+ 
+-    private var availableInputs: [PredictionInputEffect] = [.carbs, .insulin, .momentum, .retrospection, .suspend]
++    private var availableInputs: [PredictionInputEffect] = getAvailableInputs()
+ 
+     private var selectedInputs = PredictionInputEffect.all
++    
++    private static func getAvailableInputs() -> [PredictionInputEffect] {
++        if UserDefaults.standard.negativeInsulinDamperEnabled {
++            return [.carbs, .insulin, .damper, .momentum, .retrospection, .suspend]
++        }
++        return [.carbs, .insulin, .momentum, .retrospection, .suspend]
++    }
+ 
+     override func numberOfSections(in tableView: UITableView) -> Int {
+         return Section.allCases.count
+@@ -261,6 +275,20 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
+ 
+         var subtitleText = input.localizedDescription(forGlucoseUnit: glucoseChart.glucoseUnit) ?? ""
+ 
++        if input == .damper, let negativeInsulinDamper = negativeInsulinDamper {
++            let formatter = NumberFormatter()
++            formatter.minimumIntegerDigits = 1
++            formatter.maximumFractionDigits = 1
++            formatter.maximumSignificantDigits = 2
++            
++            let damper = String(
++                format: NSLocalizedString("Damper Strength: %1$@%%", comment: "Format string describing damper strength. (1: damper strength percentage)"),
++                formatter.string(from: 100 * negativeInsulinDamper) ?? "?"
++            )
++            
++            subtitleText = String(format: "%@\n%@", subtitleText, damper)
++            
++        }
+         if input == .retrospection,
+             let lastDiscrepancy = retrospectiveGlucoseDiscrepancies?.last,
+             let currentGlucose = deviceManager.glucoseStore.latestGlucose
+diff --git a/Loop/Loop/Views/LiveActivityManagementView.swift b/Loop/Loop/Views/LiveActivityManagementView.swift
+index bdf87dc5..f7f875ca 100644
+--- a/Loop/Loop/Views/LiveActivityManagementView.swift
++++ b/Loop/Loop/Views/LiveActivityManagementView.swift
+@@ -14,18 +14,12 @@ import HealthKit
+ struct LiveActivityManagementView: View {
+     @EnvironmentObject private var displayGlucosePreference: DisplayGlucosePreference
+     @StateObject private var viewModel = LiveActivityManagementViewModel()
+-    @State private var previousViewModel = LiveActivityManagementViewModel()
+-    
+-    @State private var isDirty = false
+    
+     var body: some View {
+         VStack {
+             List {
+                 Section {
+                     Toggle(NSLocalizedString("Enabled", comment: "Title for enable live activity toggle"), isOn: $viewModel.enabled)
+-                        .onChange(of: viewModel.enabled) { _ in
+-                            self.isDirty = previousViewModel.enabled != viewModel.enabled
+-                        }
+                     
+                     ExpandableSetting(
+                         isEditing: $viewModel.isEditingMode,
+@@ -43,48 +37,29 @@ struct LiveActivityManagementView: View {
+                                              formatter: { $0.name() })
+                         }
+                     )
+-                    .onChange(of: viewModel.mode) { _ in
+-                        self.isDirty = previousViewModel.mode != viewModel.mode
+-                    }
+                 }
+                 
+                 Section {
+                     if viewModel.mode == .large {
+                         Toggle(NSLocalizedString("Add predictive line", comment: "Title for predictive line toggle"), isOn: $viewModel.addPredictiveLine)
+                             .transition(.move(edge: viewModel.mode == .large ? .top : .bottom))
+-                            .onChange(of: viewModel.addPredictiveLine) { _ in
+-                                self.isDirty = previousViewModel.addPredictiveLine != viewModel.addPredictiveLine
+-                            }
+                     }
+                     
+                     Toggle(NSLocalizedString("Use BG coloring", comment: "Title for BG coloring"), isOn: $viewModel.useLimits)
+                         .transition(.move(edge: viewModel.mode == .large ? .top : .bottom))
+-                        .onChange(of: viewModel.useLimits) { _ in
+-                            self.isDirty = previousViewModel.useLimits != viewModel.useLimits
+-                        }
+                     
+-                    if self.displayGlucosePreference.unit == .millimolesPerLiter {
+-                        TextInput(label: "Upper limit", value: $viewModel.upperLimitChartMmol)
+-                            .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
+-                            .onChange(of: viewModel.upperLimitChartMmol) { _ in
+-                                self.isDirty = previousViewModel.upperLimitChartMmol != viewModel.upperLimitChartMmol
+-                            }
+-                        TextInput(label: "Lower limit", value: $viewModel.lowerLimitChartMmol)
+-                            .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
+-                            .onChange(of: viewModel.lowerLimitChartMmol) { _ in
+-                                self.isDirty = previousViewModel.lowerLimitChartMmol != viewModel.lowerLimitChartMmol
+-                            }
+-                    } else {
+-                        TextInput(label: "Upper limit", value: $viewModel.upperLimitChartMg)
+-                            .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
+-                            .onChange(of: viewModel.upperLimitChartMg) { _ in
+-                                self.isDirty = previousViewModel.upperLimitChartMg != viewModel.upperLimitChartMg
+-                            }
+-                        TextInput(label: "Lower limit", value: $viewModel.lowerLimitChartMg)
+-                            .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
+-                            .onChange(of: viewModel.lowerLimitChartMg) { _ in
+-                                self.isDirty = previousViewModel.lowerLimitChartMg != viewModel.lowerLimitChartMg
+-                            }
++                    if viewModel.useLimits {
++                        if self.displayGlucosePreference.unit == .millimolesPerLiter {
++                            TextInput(label: "Upper limit", value: $viewModel.upperLimitChartMmol)
++                                .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
++                            TextInput(label: "Lower limit", value: $viewModel.lowerLimitChartMmol)
++                                .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
++                        } else {
++                            TextInput(label: "Upper limit", value: $viewModel.upperLimitChartMg)
++                                .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
++                            TextInput(label: "Lower limit", value: $viewModel.lowerLimitChartMg)
++                                .transition(.move(edge: viewModel.useLimits ? .top : .bottom))
++                        }
+                     }
+                 }
+                 
+@@ -94,6 +69,8 @@ struct LiveActivityManagementView: View {
+                         label: { Text(NSLocalizedString("Bottom row configuration", comment: "Title for Bottom row configuration")) }
+                     )
+                 }
++                
++                
+             }
+             .animation(.easeInOut, value: UUID())
+             .insetGroupedListStyle()
+@@ -103,7 +80,6 @@ struct LiveActivityManagementView: View {
+                 Text(NSLocalizedString("Save", comment: ""))
+             }
+             .buttonStyle(ActionButtonStyle())
+-            .disabled(!isDirty)
+             .padding([.bottom, .horizontal])
+         }
+             .navigationBarTitle(Text(NSLocalizedString("Live activity", comment: "Live activity screen title")))
+@@ -133,8 +109,5 @@ struct LiveActivityManagementView: View {
+         
+         UserDefaults.standard.liveActivity = settings
+         NotificationCenter.default.post(name: .LiveActivitySettingsChanged, object: settings)
+-        
+-        self.isDirty = false
+-        previousViewModel = LiveActivityManagementViewModel()
+     }
+ }
+diff --git a/Loop/Loop/Views/NegativeInsulinDamperSelectionView.swift b/Loop/Loop/Views/NegativeInsulinDamperSelectionView.swift
+new file mode 100644
+index 00000000..4f14233c
+--- /dev/null
++++ b/Loop/Loop/Views/NegativeInsulinDamperSelectionView.swift
+@@ -0,0 +1,42 @@
++//
++//  NegativeInsulinDamperSelectionView.swift
++//  Loop
++//
++//  Created by Moti Nisenson-Ken on 16/10/2024.
++//  Copyright © 2024 LoopKit Authors. All rights reserved.
++//
++import Foundation
++import SwiftUI
++import LoopKit
++import LoopKitUI
++
++struct NegativeInsulinDamperSelectionView: View {
++   @Binding var isNegativeInsulinDamperEnabled: Bool
++   
++   public var body: some View {
++       ScrollView {
++           VStack(spacing: 10) {
++               Text(NSLocalizedString("Negative Insulin Damper", comment: "Title for negative insulin damper experiment description"))
++                   .font(.headline)
++                   .padding(.bottom, 20)
++
++               Divider()
++
++               Text(NSLocalizedString("Negative Insulin Damper (NID) is used to mitigate the effects of temporarily increased insulin sensitivity. Such increases can result in spending significant times beneath target and eventually going low. Loop may erroneously predict glucose going too high, resulting in excess insulin being delivered. To counteract this, NID acts as a dynamic damper on increases to  predicted glucose. The strength of this damper is controlled by the total predicted rise in glucose due to negative insulin. The greater the amount of negative insulin, the stronger the damper and the bigger the reductions. The calculation is done with a 15 minute lag.", comment: "Description of Negative Insulin Damper toggle."))
++                   .foregroundColor(.secondary)
++               Divider()
++
++               Toggle(NSLocalizedString("Enable Negative Insulin Damper", comment: "Title for Negative Insulin Damper toggle"), isOn: $isNegativeInsulinDamperEnabled)
++                   .padding(.top, 20)
++           }
++           .padding()
++       }
++       .navigationBarTitleDisplayMode(.inline)
++   }
++
++   struct NegativeInsulinDamperSelectionView_Previews: PreviewProvider {
++       static var previews: some View {
++           NegativeInsulinDamperSelectionView(isNegativeInsulinDamperEnabled: .constant(true))
++       }
++   }
++}
+diff --git a/Loop/Loop/Views/SettingsView+algorithmExperimentsSection.swift b/Loop/Loop/Views/SettingsView+algorithmExperimentsSection.swift
+index 54bd2c71..4ed38456 100644
+--- a/Loop/Loop/Views/SettingsView+algorithmExperimentsSection.swift
++++ b/Loop/Loop/Views/SettingsView+algorithmExperimentsSection.swift
+@@ -39,8 +39,10 @@ public struct ExperimentRow: View {
+ }
+ 
+ public struct ExperimentsSettingsView: View {
+     @AppStorage(UserDefaults.Key.GlucoseBasedApplicationFactorEnabled.rawValue) private var isGlucoseBasedApplicationFactorEnabled = false
+     @AppStorage(UserDefaults.Key.IntegralRetrospectiveCorrectionEnabled.rawValue) private var isIntegralRetrospectiveCorrectionEnabled = false
++    @AppStorage(UserDefaults.Key.NegativeInsulinDamperEnabled.rawValue) private var isNegativeInsulinDamperEnabled = false
++
+     var automaticDosingStrategy: AutomaticDosingStrategy
+ 
+     public var body: some View {
+@@ -70,6 +72,11 @@ public struct ExperimentsSettingsView: View {
+                         name: NSLocalizedString("Integral Retrospective Correction", comment: "Title of integral retrospective correction experiment"),
+                         enabled: isIntegralRetrospectiveCorrectionEnabled)
+                 }
++                NavigationLink(destination: NegativeInsulinDamperSelectionView(isNegativeInsulinDamperEnabled: $isNegativeInsulinDamperEnabled)) {
++                    ExperimentRow(
++                        name: NSLocalizedString("Negative Insulin Damper", comment: "Title of negative insulin damper experiment"),
++                        enabled: isNegativeInsulinDamperEnabled)
++                }
+                 Spacer()
+             }
+             .padding()
+@@ -80,9 +87,10 @@ public struct ExperimentsSettingsView: View {
+ 
+ 
+ extension UserDefaults {
+     fileprivate enum Key: String {
+         case GlucoseBasedApplicationFactorEnabled = "com.loopkit.algorithmExperiments.glucoseBasedApplicationFactorEnabled"
+         case IntegralRetrospectiveCorrectionEnabled = "com.loopkit.algorithmExperiments.integralRetrospectiveCorrectionEnabled"
++        case NegativeInsulinDamperEnabled = "com.loopkit.algorithmExperiments.negativeInsulinDamperEnabled"
+     }
+ 
+     var glucoseBasedApplicationFactorEnabled: Bool {
+@@ -103,4 +111,12 @@ extension UserDefaults {
+         }
+     }
+ 
++    var negativeInsulinDamperEnabled: Bool {
++        get {
++            bool(forKey: Key.NegativeInsulinDamperEnabled.rawValue) as Bool
++        }
++        set {
++            set(newValue, forKey: Key.NegativeInsulinDamperEnabled.rawValue)
++        }
++    }
+ }
+diff --git a/Loop/LoopCore/LiveActivitySettings.swift b/Loop/LoopCore/LiveActivitySettings.swift
+index d0f892f7..71807464 100644
+--- a/Loop/LoopCore/LiveActivitySettings.swift
++++ b/Loop/LoopCore/LiveActivitySettings.swift
+@@ -117,7 +117,7 @@ public struct LiveActivitySettings: Codable, Equatable {
+         self.enabled = try values.decode(Bool.self, forKey: .enabled)
+         self.mode = try values.decodeIfPresent(LiveActivityMode.self, forKey: .mode) ?? .large
+         self.addPredictiveLine = try values.decode(Bool.self, forKey: .addPredictiveLine)
+-        self.useLimits = try values.decode(Bool.self, forKey: .useLimits)
++        self.useLimits = try values.decodeIfPresent(Bool.self, forKey: .useLimits) ?? true
+         self.upperLimitChartMmol = try values.decode(Double?.self, forKey: .upperLimitChartMmol) ?? LiveActivitySettings.defaultUpperLimitMmol
+         self.lowerLimitChartMmol = try values.decode(Double?.self, forKey: .lowerLimitChartMmol) ?? LiveActivitySettings.defaultLowerLimitMmol
+         self.upperLimitChartMg = try values.decode(Double?.self, forKey: .upperLimitChartMg) ?? LiveActivitySettings.defaultUpperLimitMg
+@@ -156,4 +156,4 @@ public struct LiveActivitySettings: Codable, Equatable {
+             lhs.lowerLimitChartMg != rhs.lowerLimitChartMg ||
+             lhs.upperLimitChartMg != rhs.upperLimitChartMg
+     }
+-}
++}
+\ No newline at end of file
+diff --git a/Loop/LoopTests/Managers/LoopDataManagerDosingTests.swift b/Loop/LoopTests/Managers/LoopDataManagerDosingTests.swift
+index a1f26a0e..000d2e7e 100644
+--- a/Loop/LoopTests/Managers/LoopDataManagerDosingTests.swift
++++ b/Loop/LoopTests/Managers/LoopDataManagerDosingTests.swift
+@@ -52,6 +52,38 @@ class LoopDataManagerDosingTests: LoopDataManagerTests {
+         let url = bundle.url(forResource: name, withExtension: "json")!
+         return try! decoder.decode([PredictedGlucoseValue].self, from: try! Data(contentsOf: url))
+     }
++    
++    func testNegativeInsulinDamper() {
++        let marginalSlope = 0.05
++        let anchorAlpha = 0.75
++        let anchorPoint = 50.0
++
++        XCTAssertEqual(1.0, LoopDataManager.calculateNegativeInsulinDamperAlpha(anchorAlpha, anchorPoint, marginalSlope, 0))
++
++        XCTAssertEqual(anchorAlpha, LoopDataManager.calculateNegativeInsulinDamperAlpha(anchorAlpha, anchorPoint, marginalSlope, anchorPoint), accuracy: 1E-6)
++        
++        let linearScaleSlope = (1 - anchorAlpha)/anchorPoint
++        let transitionPoint = (1 - marginalSlope) / (2 * linearScaleSlope)
++        let transitionValue = (1 - linearScaleSlope * transitionPoint) * transitionPoint
++        
++        XCTAssertEqual(marginalSlope, LoopDataManager.calculateNegativeInsulinDamperAlpha(anchorAlpha, anchorPoint, marginalSlope, 1E12), accuracy: 1E-6)
++        
++        var prevAlpha = 1.1
++        for i in 0...1_000_000 {
++            let iVal = Double(i)
++            let alpha = LoopDataManager.calculateNegativeInsulinDamperAlpha(anchorAlpha, anchorPoint, marginalSlope, iVal)
++            
++            XCTAssertLessThan(alpha, prevAlpha)
++            XCTAssertGreaterThan(alpha, marginalSlope)
++            
++            if Double(i) <= transitionPoint {
++                XCTAssertEqual(alpha, 1.0 - iVal * linearScaleSlope, accuracy: 1E-6)
++            } else {
++                XCTAssertEqual(alpha * iVal, transitionValue + marginalSlope * (iVal - transitionPoint), accuracy: 1E-6)
++            }
++            prevAlpha = alpha
++        }
++    }
+ 
+     // MARK: Tests
+     func testForecastFromLiveCaptureInputData() {
+diff --git a/Loop/LoopTests/Mock Stores/MockDoseStore.swift b/Loop/LoopTests/Mock Stores/MockDoseStore.swift
+index 207596f3..4c5d945a 100644
+--- a/Loop/LoopTests/Mock Stores/MockDoseStore.swift	
++++ b/Loop/LoopTests/Mock Stores/MockDoseStore.swift	
+@@ -90,11 +90,11 @@ class MockDoseStore: DoseStoreProtocol {
+         completion(.failure(.configurationError))
+     }
+     
+-    func getGlucoseEffects(start: Date, end: Date? = nil, basalDosingEnd: Date? = Date(), completion: @escaping (_ result: DoseStoreResult<[GlucoseEffect]>) -> Void) {
++    func getGlucoseEffects(start: Date, end: Date? = nil, doseEnd: Date? = nil, basalDosingEnd: Date? = Date(), completion: @escaping (_ result: DoseStoreResult<[GlucoseEffect]>) -> Void) {
+         if let doseHistory, let sensitivitySchedule, let basalProfile = basalProfileApplyingOverrideHistory {
+             // To properly know glucose effects at startDate, we need to go back another DIA hours
+             let doseStart = start.addingTimeInterval(-longestEffectDuration)
+-            let doses = doseHistory.filterDateRange(doseStart, end)
++            let doses = doseHistory.filterDateRange(doseStart, doseEnd ?? end)
+             let trimmedDoses = doses.map { (dose) -> DoseEntry in
+                 guard dose.type != .bolus else {
+                     return dose
+diff --git a/Loop/LoopTests/ViewModels/BolusEntryViewModelTests.swift b/Loop/LoopTests/ViewModels/BolusEntryViewModelTests.swift
+index 7f2c421e..32cb63ca 100644
+--- a/Loop/LoopTests/ViewModels/BolusEntryViewModelTests.swift
++++ b/Loop/LoopTests/ViewModels/BolusEntryViewModelTests.swift
+@@ -822,6 +822,8 @@ fileprivate class MockLoopState: LoopState {
+     
+     var totalRetrospectiveCorrection: HKQuantity?
+     
++    var negativeInsulinDamper: Double?
++    
+     var predictGlucoseValueResult: [PredictedGlucoseValue] = []
+     func predictGlucose(using inputs: PredictionInputEffect, potentialBolus: DoseEntry?, potentialCarbEntry: NewCarbEntry?, replacingCarbEntry replacedCarbEntry: StoredCarbEntry?, includingPendingInsulin: Bool, considerPositiveVelocityAndRC: Bool) throws -> [PredictedGlucoseValue] {
+         return predictGlucoseValueResult
+Submodule LoopKit a03be57..d1745ae:
+diff --git a/LoopKit/LoopKit/Insulin/ExponentialInsulinModelPreset.swift b/LoopKit/LoopKit/Insulin/ExponentialInsulinModelPreset.swift
+index 7ba9842c..baf4d7ac 100644
+--- a/LoopKit/LoopKit/Insulin/ExponentialInsulinModelPreset.swift
++++ b/LoopKit/LoopKit/Insulin/ExponentialInsulinModelPreset.swift
+@@ -63,22 +63,16 @@ extension ExponentialInsulinModelPreset {
+         }
+     }
+     
+-    var model: InsulinModel {
++    public var model: InsulinModel {
+         return ExponentialInsulinModel(actionDuration: actionDuration, peakActivityTime: peakActivity, delay: delay)
+     }
+-}
+-
+-
+-extension ExponentialInsulinModelPreset: InsulinModel {
+-    public var effectDuration: TimeInterval {
++    
++    public var effectDuration : TimeInterval {
+         return model.effectDuration
+     }
+-
+-    public func percentEffectRemaining(at time: TimeInterval) -> Double {
+-        return model.percentEffectRemaining(at: time)
+-    }
+ }
+ 
++
+ extension ExponentialInsulinModelPreset: CustomDebugStringConvertible {
+     public var debugDescription: String {
+         return "\(self.rawValue)(\(String(reflecting: model)))"
+diff --git a/LoopKit/LoopKit/Insulin/InsulinModelProvider.swift b/LoopKit/LoopKit/Insulin/InsulinModelProvider.swift
+index f99aca82..f067d6bf 100644
+--- a/LoopKit/LoopKit/Insulin/InsulinModelProvider.swift
++++ b/LoopKit/LoopKit/Insulin/InsulinModelProvider.swift
+@@ -10,22 +10,22 @@ public protocol InsulinModelProvider {
+ }
+ 
+ public struct PresetInsulinModelProvider: InsulinModelProvider {
+-    var defaultRapidActingModel: InsulinModel?
++    var defaultRapidActingModel: ExponentialInsulinModelPreset?
+     
+-    public init(defaultRapidActingModel: InsulinModel?) {
++    public init(defaultRapidActingModel: ExponentialInsulinModelPreset?) {
+         self.defaultRapidActingModel = defaultRapidActingModel
+     }
+     
+     public func model(for type: InsulinType?) -> InsulinModel {
+         switch type {
+         case .fiasp:
+-            return ExponentialInsulinModelPreset.fiasp
++            return ExponentialInsulinModelPreset.fiasp.model
+         case .lyumjev:
+-            return ExponentialInsulinModelPreset.lyumjev
++            return ExponentialInsulinModelPreset.lyumjev.model
+         case .afrezza:
+-            return ExponentialInsulinModelPreset.afrezza
++            return ExponentialInsulinModelPreset.afrezza.model
+         default:
+-            return defaultRapidActingModel ?? ExponentialInsulinModelPreset.rapidActingAdult
++            return (defaultRapidActingModel ?? ExponentialInsulinModelPreset.rapidActingAdult).model
+         }
+     }
+ }
+@@ -38,6 +38,10 @@ public struct StaticInsulinModelProvider: InsulinModelProvider {
+         self.model = model
+     }
+     
++    public init(_ preset: ExponentialInsulinModelPreset) {
++        self.model = preset.model
++    }
++    
+     public func model(for type: InsulinType?) -> InsulinModel {
+         return model
+     }
+diff --git a/LoopKit/LoopKit/InsulinKit/DoseStore.swift b/LoopKit/LoopKit/InsulinKit/DoseStore.swift
+index 5efe99ff..7be9c02f 100644
+--- a/LoopKit/LoopKit/InsulinKit/DoseStore.swift
++++ b/LoopKit/LoopKit/InsulinKit/DoseStore.swift
+@@ -1333,10 +1333,11 @@ extension DoseStore {
+     /// - Parameters:
+     ///   - start: The earliest date of effects to retrieve
+     ///   - end: The latest date of effects to retrieve, if provided
++    ///   - doseEnd: the latest startDate of doses whose effects will be considered. If not provided, then equal to end.
+     ///   - basalDosingEnd: The date at which continuing doses should be assumed to be cancelled
+     ///   - completion: A closure called once the effects have been retrieved
+     ///   - result: An array of effects, in chronological order
+-    public func getGlucoseEffects(start: Date, end: Date? = nil, basalDosingEnd: Date? = Date(), completion: @escaping (_ result: DoseStoreResult<[GlucoseEffect]>) -> Void) {
++    public func getGlucoseEffects(start: Date, end: Date? = nil, doseEnd: Date? = nil, basalDosingEnd: Date? = Date(), completion: @escaping (_ result: DoseStoreResult<[GlucoseEffect]>) -> Void) {
+         guard let insulinSensitivitySchedule = self.insulinSensitivityScheduleApplyingOverrideHistory else {
+             completion(.failure(.configurationError))
+             return
+@@ -1344,7 +1345,7 @@ extension DoseStore {
+ 
+         // To properly know glucose effects at startDate, we need to go back another DIA hours
+         let doseStart = start.addingTimeInterval(-longestEffectDuration)
+-        getNormalizedDoseEntries(start: doseStart, end: end) { (result) in
++        getNormalizedDoseEntries(start: doseStart, end: doseEnd ?? end) { (result) in
+             switch result {
+             case .failure(let error):
+                 completion(.failure(error))
+diff --git a/LoopKit/LoopKitTests/DoseStoreTests.swift b/LoopKit/LoopKitTests/DoseStoreTests.swift
+index 93777b09..bdb72ae8 100644
+--- a/LoopKit/LoopKitTests/DoseStoreTests.swift
++++ b/LoopKit/LoopKitTests/DoseStoreTests.swift
+@@ -1428,7 +1428,7 @@ class DoseStoreEffectTests: PersistenceControllerTestCase {
+     override func setUp() {
+         super.setUp()
+         let healthStore = HKHealthStoreMock()
+-        let exponentialInsulinModel: InsulinModel = ExponentialInsulinModelPreset.rapidActingAdult
++        let exponentialInsulinModel: InsulinModel = ExponentialInsulinModelPreset.rapidActingAdult.model
+         let startDate = dateFormatter.date(from: "2015-07-13T12:00:00")!
+ 
+         let sampleStore = HealthKitSampleStore(

--- a/profiles/dev377_profiles.patch
+++ b/profiles/dev377_profiles.patch
@@ -1,0 +1,1432 @@
+Submodule Loop b6610a1..6e6b0f2:
+diff --git a/Loop/Loop/Managers/DeviceDataManager.swift b/Loop/Loop/Managers/DeviceDataManager.swift
+index 2751f18f..4866c85c 100644
+--- a/Loop/Loop/Managers/DeviceDataManager.swift
++++ b/Loop/Loop/Managers/DeviceDataManager.swift
+@@ -1636,6 +1636,10 @@ extension DeviceDataManager: TherapySettingsViewModelDelegate {
+         }
+     }
+     
++    func updateCurrentProfileName() {
++        loopManager.updateCurrentProfileName()
++    }
++    
+     func saveCompletion(therapySettings: TherapySettings) {
+ 
+         loopManager.mutateSettings { settings in
+diff --git a/Loop/Loop/Managers/LoopDataManager.swift b/Loop/Loop/Managers/LoopDataManager.swift
+index 2319f4ec..63164e69 100644
+--- a/Loop/Loop/Managers/LoopDataManager.swift
++++ b/Loop/Loop/Managers/LoopDataManager.swift
+@@ -229,6 +229,10 @@ final class LoopDataManager {
+         lockedSettings.value
+     }
+ 
++    func updateCurrentProfileName () {
++        notify(forChange: .preferences)
++    }
++    
+     func mutateSettings(_ changes: (_ settings: inout LoopSettings) -> Void) {
+         var oldValue: LoopSettings!
+         let newValue = lockedSettings.mutate { settings in
+diff --git a/Loop/Loop/Views/SettingsView.swift b/Loop/Loop/Views/SettingsView.swift
+index c3ec98b8..74045900 100644
+--- a/Loop/Loop/Views/SettingsView.swift
++++ b/Loop/Loop/Views/SettingsView.swift
+@@ -51,6 +51,7 @@ public struct SettingsView: View {
+             
+             case favoriteFoods
+             case therapySettings
++            case profiles
+         }
+     }
+     
+@@ -157,6 +158,19 @@ public struct SettingsView: View {
+                     .environment(\.insulinTintColor, self.insulinTintColor)
+                 case .favoriteFoods:
+                     FavoriteFoodsView()
++                case .profiles:
++                    ProfileView(viewModel: ProfileViewModel(therapySettings: self.viewModel.therapySettings(),
++                                                            sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
++                                                            adultChildInsulinModelSelectionEnabled: FeatureFlags.adultChildInsulinModelSelectionEnabled,
++                                                            delegate: self.viewModel.therapySettingsViewModelDelegate))
++                    .environmentObject(displayGlucosePreference)
++                    .environment(\.dismissAction, self.dismiss)
++                    .environment(\.appName, self.appName)
++                    .environment(\.chartColorPalette, .primary)
++                    .environment(\.carbTintColor, self.carbTintColor)
++                    .environment(\.glucoseTintColor, self.glucoseTintColor)
++                    .environment(\.guidanceColors, self.guidanceColors)
++                    .environment(\.insulinTintColor, self.insulinTintColor)
+                 }
+             }
+         }
+@@ -294,7 +308,11 @@ extension SettingsView {
+                             imageView: Image("Therapy Icon"),
+                             label: NSLocalizedString("Therapy Settings", comment: "Title text for button to Therapy Settings"),
+                             descriptiveText: NSLocalizedString("Diabetes Treatment", comment: "Descriptive text for Therapy Settings"))
+-            
++            LargeButton(action: { sheet = .profiles },
++                        includeArrow: true,
++                        imageView: AnyView(Image(systemName: "arrow.triangle.2.circlepath").font(.system(size: 30, weight: .bold))),
++                        label: NSLocalizedString("Profiles", comment: "Title text for button to Profiles"),
++                        descriptiveText: NSLocalizedString("Switch between profiles for different scenarios", comment: "Descriptive text for Profiles"))
+             ForEach(pluginMenuItems.filter {$0.section == .configuration}) { item in
+                 item.view
+             }
+Submodule LoopKit contains modified content
+Submodule LoopKit 70d1860..4e09f44:
+diff --git a/LoopKit/LoopKit.xcodeproj/project.pbxproj b/LoopKit/LoopKit.xcodeproj/project.pbxproj
+index 8354209..f061a30 100644
+--- a/LoopKit/LoopKit.xcodeproj/project.pbxproj
++++ b/LoopKit/LoopKit.xcodeproj/project.pbxproj
+@@ -865,6 +865,12 @@
+ 		C1FAEC1D264AD6B400A3250B /* DeviceStatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FAEC1C264AD6B400A3250B /* DeviceStatusBadge.swift */; };
+ 		C1FAEC1F264AE12700A3250B /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47ECF8725DC20810024A54D /* UIImage.swift */; };
+ 		C1FAEC21264AEEA300A3250B /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FAEC20264AEEA300A3250B /* UIImage.swift */; };
++		DD508E062A17712D00EEF8FD /* ProfileViewModel+FileManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD508E052A17712D00EEF8FD /* ProfileViewModel+FileManagement.swift */; };
++		DD508E082A17763700EEF8FD /* NewProfileEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD508E072A17763700EEF8FD /* NewProfileEditor.swift */; };
++		DD7122612A1D2AA4004FE653 /* ProfilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7122602A1D2AA4004FE653 /* ProfilePreviewView.swift */; };
++		DDAF746729F422C600719F0A /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAF746629F422C600719F0A /* ProfileView.swift */; };
++		DDAF746929F4234000719F0A /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAF746829F4234000719F0A /* ProfileViewModel.swift */; };
++		DDCFC91E2AA9F702003DE656 /* RenameProfileEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCFC91D2AA9F702003DE656 /* RenameProfileEditor.swift */; };
+ 		E9077D2724ACD59F0066A88D /* InformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9077D2624ACD59F0066A88D /* InformationView.swift */; };
+ 		E9077D2A24ACDE2C0066A88D /* CorrectionRangeInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9077D2924ACDE2C0066A88D /* CorrectionRangeInformationView.swift */; };
+ 		E9086B2924B39EDC0062F5C8 /* ChartsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9086B2824B39EDC0062F5C8 /* ChartsTableViewController.swift */; };
+@@ -1790,6 +1796,12 @@
+ 		C1FAC06228C7B0A100754AE2 /* reservoir_iob_test.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reservoir_iob_test.json; sourceTree = "<group>"; };
+ 		C1FAEC1C264AD6B400A3250B /* DeviceStatusBadge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceStatusBadge.swift; sourceTree = "<group>"; };
+ 		C1FAEC20264AEEA300A3250B /* UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
++		DD508E052A17712D00EEF8FD /* ProfileViewModel+FileManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfileViewModel+FileManagement.swift"; sourceTree = "<group>"; };
++		DD508E072A17763700EEF8FD /* NewProfileEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProfileEditor.swift; sourceTree = "<group>"; };
++		DD7122602A1D2AA4004FE653 /* ProfilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePreviewView.swift; sourceTree = "<group>"; };
++		DDAF746629F422C600719F0A /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
++		DDAF746829F4234000719F0A /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
++		DDCFC91D2AA9F702003DE656 /* RenameProfileEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameProfileEditor.swift; sourceTree = "<group>"; };
+ 		E9077D2624ACD59F0066A88D /* InformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationView.swift; sourceTree = "<group>"; };
+ 		E9077D2924ACDE2C0066A88D /* CorrectionRangeInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionRangeInformationView.swift; sourceTree = "<group>"; };
+ 		E9086B2824B39EDC0062F5C8 /* ChartsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartsTableViewController.swift; sourceTree = "<group>"; };
+@@ -3167,11 +3179,13 @@
+ 			isa = PBXGroup;
+ 			children = (
+ 				B455F3A325FF7FF0000ED456 /* CorrectionRangeOverridesEditorViewModel.swift */,
++				DDAF746829F4234000719F0A /* ProfileViewModel.swift */,
+ 				B4B7C1BB2604E3FC007379F6 /* CorrectionRangeScheduleEditorViewModel.swift */,
+ 				B4D4C20C25F95A8700DA809D /* DisplayGlucosePreference.swift */,
+ 				B455F48025FF9A8B000ED456 /* InsulinSensitivityScheduleEditorViewModel.swift */,
+ 				B455F2A125FBE985000ED456 /* SuspendThresholdEditorViewModel.swift */,
+ 				1D1FCE2424BD42EF000300A8 /* TherapySettingsViewModel.swift */,
++				DD508E052A17712D00EEF8FD /* ProfileViewModel+FileManagement.swift */,
+ 			);
+ 			path = ViewModels;
+ 			sourceTree = "<group>";
+@@ -3358,6 +3372,10 @@
+ 				E96DCB5924AF74AC007117BC /* SuspendThresholdEditor.swift */,
+ 				1D1FCE2A24BE704A000300A8 /* TherapySetting+Settings.swift */,
+ 				1D1A019D24B678BF0077D86E /* TherapySettingsView.swift */,
++				DDAF746629F422C600719F0A /* ProfileView.swift */,
++				DD508E072A17763700EEF8FD /* NewProfileEditor.swift */,
++				DD7122602A1D2AA4004FE653 /* ProfilePreviewView.swift */,
++				DDCFC91D2AA9F702003DE656 /* RenameProfileEditor.swift */,
+ 			);
+ 			path = "Settings Editors";
+ 			sourceTree = "<group>";
+@@ -4062,6 +4080,7 @@
+ 				E9086B4824B5405E0062F5C8 /* ChartAxisValueDoubleUnit.swift in Sources */,
+ 				B429D66C24BF7204003E1B4A /* GlucoseTrend.swift in Sources */,
+ 				432CF86720D76AB90066B889 /* SettingsTableViewCell.swift in Sources */,
++				DD508E082A17763700EEF8FD /* NewProfileEditor.swift in Sources */,
+ 				898B4E7B246DC6A70053C484 /* CorrectionRangeScheduleEditor.swift in Sources */,
+ 				E9E5E56A24D5CCE800B5DFFE /* OverrideViewCell.swift in Sources */,
+ 				892A5DB42231E191008961AB /* LevelMaskView.swift in Sources */,
+@@ -4071,6 +4090,7 @@
+ 				B43D69D62A26642300DF0925 /* DemoPlaceHolderView.swift in Sources */,
+ 				E949E38F24B3711E00024DA0 /* InsulinModelInformationView.swift in Sources */,
+ 				895FE08B22011F0C00FCF18A /* EmojiInputHeaderView.swift in Sources */,
++				DDCFC91E2AA9F702003DE656 /* RenameProfileEditor.swift in Sources */,
+ 				895FE08322011F0C00FCF18A /* OverrideSelectionFooterView.swift in Sources */,
+ 				89AF78C22447E353002B4FCC /* Splat.swift in Sources */,
+ 				893C9F8C2447DBD900CD4185 /* CardBuilder.swift in Sources */,
+@@ -4121,9 +4141,11 @@
+ 				E9C58A6E24DA65E400487A17 /* HistoricalOverrideDetailView.swift in Sources */,
+ 				895FE08222011F0C00FCF18A /* LabeledTextFieldTableViewCell.swift in Sources */,
+ 				B43DA44224D9CD8500CAFF4E /* Environment+Colors.swift in Sources */,
++				DD508E062A17712D00EEF8FD /* ProfileViewModel+FileManagement.swift in Sources */,
+ 				892A5DB22231E191008961AB /* LoadingTableViewCell.swift in Sources */,
+ 				B4D3D4AD25B8A94E0085BA0F /* DisplayGlucoseUnitObserver.swift in Sources */,
+ 				A9D3FF102A6C19CA000C891D /* ChartAxisValueDoubleLog.swift in Sources */,
++				DD7122612A1D2AA4004FE653 /* ProfilePreviewView.swift in Sources */,
+ 				E96DCB5A24AF74AC007117BC /* SuspendThresholdEditor.swift in Sources */,
+ 				E96DCB5824AEF50F007117BC /* SuspendThresholdInformationView.swift in Sources */,
+ 				A9D3FF0C2A6C198C000C891D /* CollectionType.swift in Sources */,
+@@ -4199,6 +4221,7 @@
+ 				E93C86B624D08CAD0073089B /* InsulinSensitivityInformationView.swift in Sources */,
+ 				C18733AF29B9492300519CDF /* Collection.swift in Sources */,
+ 				892A5DA22231E137008961AB /* HUDProvider.swift in Sources */,
++				DDAF746929F4234000719F0A /* ProfileViewModel.swift in Sources */,
+ 				898E6E6C224194060019E459 /* UIColor.swift in Sources */,
+ 				43BA717D201EE7090058961E /* GlucoseRangeTableViewCell.swift in Sources */,
+ 				B455F3A425FF7FF0000ED456 /* CorrectionRangeOverridesEditorViewModel.swift in Sources */,
+@@ -4225,6 +4248,7 @@
+ 				1D1065E9282DC54700026A70 /* VideoPlayView.swift in Sources */,
+ 				E99A132E2557548300D3F5B3 /* SegmentedGaugeBar.swift in Sources */,
+ 				B455F31825FBEC5F000ED456 /* SuspendThresholdEditorViewModel.swift in Sources */,
++				DDAF746729F422C600719F0A /* ProfileView.swift in Sources */,
+ 				892A5DB32231E191008961AB /* LevelHUDView.swift in Sources */,
+ 				B41A60B223D1DBC700636320 /* UIFont.swift in Sources */,
+ 				B41A60AF23D1DB5B00636320 /* TableViewTitleLabel.swift in Sources */,
+diff --git a/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
+new file mode 100644
+index 0000000..74724fb
+--- /dev/null
++++ b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
+@@ -0,0 +1,408 @@
++//
++//  ProfileViewModel+FileManagement.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2023-05-19.
++//  Copyright © 2023 LoopKit Authors. All rights reserved.
++//
++
++import LoopKit
++import HealthKit
++
++public enum ProfileValidationError: Error, LocalizedError {
++    case fileLoadError
++    case unsupportedIncrement
++    case correctionRangeError
++    case insulinSensitivityError
++    case carbRatioError
++    case basalRateError
++    case maxBasalRateNotSet
++
++    public var errorDescription: String? {
++        switch self {
++        case .fileLoadError:
++            return "Unable to load the profile file."
++        case .unsupportedIncrement:
++            return "The profile contains unsupported increments."
++        case .correctionRangeError:
++            return "Correction Range values are out of bounds."
++        case .insulinSensitivityError:
++            return "Insulin Sensitivity values are out of bounds."
++        case .carbRatioError:
++            return "Carb Ratio values are out of bounds."
++        case .basalRateError:
++            return "Basal Rate values are out of bounds."
++        case .maxBasalRateNotSet:
++            return "Maximum Basal Rate is not set."
++        }
++    }
++}
++
++public enum LoadProfileResult {
++    case success
++    case failure(Error)
++}
++
++// MARK: File management
++extension ProfileViewModel {
++    private func setCurrentProfile(name: String, syncChange: Bool = false) {
++        let sanitizedProfileName = sanitizeProfileName(name)
++        currentProfileName = sanitizedProfileName
++        if syncChange {
++            triggerProfileSync()
++        }
++    }
++    
++    private func clearCurrentProfile() {
++        currentProfileName = nil
++        triggerProfileSync()
++    }
++    
++    private func getCurrentProfileName() -> String? {
++        return currentProfileName
++    }
++    
++    private var profilesDirectory: URL {
++        let fileManager = FileManager.default
++        let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
++        return documentsDirectory.appendingPathComponent("LoopProfile")
++    }
++
++    private func createProfileDirectoryIfNotExists() throws {
++        let fileManager = FileManager.default
++        var isDir : ObjCBool = false
++        if !fileManager.fileExists(atPath: profilesDirectory.path, isDirectory: &isDir) {
++            try fileManager.createDirectory(at: profilesDirectory, withIntermediateDirectories: true, attributes: nil)
++        } else if !isDir.boolValue {
++            throw NSError(domain: NSCocoaErrorDomain, code: NSFileWriteFileExistsError, userInfo: nil)
++        }
++    }
++
++    private func getAllProfileFiles() throws -> [URL] {
++        let fileManager = FileManager.default
++        let files = try fileManager.contentsOfDirectory(at: profilesDirectory, includingPropertiesForKeys: nil)
++        return files.filter { $0.pathExtension == "json" }
++    }
++
++    private func encodeProfile(_ profile: Profile) throws -> Data {
++        return try JSONEncoder().encode(profile)
++    }
++
++    private func decodeProfile(from data: Data) throws -> Profile {
++        return try JSONDecoder().decode(Profile.self, from: data)
++    }
++
++    public func sanitizeProfileName(_ name: String) -> String {
++        // Replace problematic characters
++        var sanitized = name.replacingOccurrences(of: ".", with: "_")
++        sanitized = sanitized.replacingOccurrences(of: "<", with: "_")
++
++        // Limit the name to 32 characters
++        if sanitized.count > 32 {
++            sanitized = String(sanitized.prefix(32))
++        }
++
++        return sanitized
++    }
++
++    public func saveProfile(withName name: String) {
++        let sanitizedName = sanitizeProfileName(name)
++
++        do {
++            try createProfileDirectoryIfNotExists()
++
++            if let existingProfile = getProfileReference(withName: sanitizedName) {
++                removeProfile(profileReference: existingProfile)
++            }
++
++            let profile = Profile(
++                name: sanitizedName,
++                correctionRange: (therapySettings.glucoseTargetRangeSchedule?.schedule(for: .milligramsPerDeciliter)!)!,
++                carbRatioSchedule: therapySettings.carbRatioSchedule!,
++                basalRateSchedule: therapySettings.basalRateSchedule!,
++                insulinSensitivitySchedule: (therapySettings.insulinSensitivitySchedule?.schedule(for: .milligramsPerDeciliter)!)!,
++                sortOrder: -1
++            )
++
++            let jsonData = try encodeProfile(profile)
++
++            let dateFormatter = DateFormatter()
++            dateFormatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
++            let fileName = dateFormatter.string(from: Date()) + ".json"
++            let fileURL = profilesDirectory.appendingPathComponent(fileName)
++
++            try jsonData.write(to: fileURL)
++            setCurrentProfile(name: sanitizedName, syncChange: true)
++
++            self.loadProfiles()
++        } catch {
++            print("An error occurred while saving profile: \(error)")
++        }
++    }
++
++    public func renameProfile(oldName: String, newName: String) {
++        let sanitizedProfileName = sanitizeProfileName(newName)
++
++        if currentProfileName == oldName {
++            setCurrentProfile(name: sanitizedProfileName, syncChange: true)
++        }
++        
++        do {
++            guard let profileReference = getProfileReference(withName: oldName) else {
++                print("Profile with old name not found.")
++                return
++            }
++            
++            let profile = try getProfile(from: profileReference)
++            
++            let newProfile = Profile(
++                name: sanitizedProfileName,
++                correctionRange: profile.correctionRange,
++                carbRatioSchedule: profile.carbRatioSchedule,
++                basalRateSchedule: profile.basalRateSchedule,
++                insulinSensitivitySchedule: profile.insulinSensitivitySchedule,
++                sortOrder: profile.sortOrder
++            )
++            
++            if let existingProfile = getProfileReference(withName: sanitizedProfileName) {
++                removeProfile(profileReference: existingProfile)
++            }
++            
++            let jsonData = try encodeProfile(newProfile)
++            let fileURL = profilesDirectory.appendingPathComponent(profileReference.fileName)
++            
++            try jsonData.write(to: fileURL)
++            
++            self.loadProfiles()
++        } catch {
++            print("An error occurred while renaming profile: \(error)")
++        }
++    }
++
++    public func updateProfilesOrder() {
++        for (index, profileReference) in profiles.enumerated() {
++            do {
++                var profile = try getProfile(from: profileReference)
++                let newProfile = Profile(
++                    name: profile.name,
++                    correctionRange: profile.correctionRange,
++                    carbRatioSchedule: profile.carbRatioSchedule,
++                    basalRateSchedule: profile.basalRateSchedule,
++                    insulinSensitivitySchedule: profile.insulinSensitivitySchedule,
++                    sortOrder: index
++                )
++                
++                let jsonData = try encodeProfile(newProfile)
++                let fileURL = profilesDirectory.appendingPathComponent(profileReference.fileName)
++                try jsonData.write(to: fileURL)
++                
++            } catch {
++                print("An error occurred while updating profile order: \(error)")
++            }
++        }
++        loadProfiles()
++    }
++    
++    public func loadProfiles() {
++        do {
++            let profileFiles = try getAllProfileFiles()
++            
++            var newProfiles = [ProfileReference]()
++            for fileURL in profileFiles {
++                let data = try Data(contentsOf: fileURL)
++                let profile = try decodeProfile(from: data)
++                let profileRef = ProfileReference(name: sanitizeProfileName(profile.name), fileName: fileURL.lastPathComponent, sortOrder: profile.sortOrder)
++                newProfiles.append(profileRef)
++            }
++            
++            newProfiles.sort { $0.sortOrder ?? 0 < $1.sortOrder ?? 0 }
++            
++            self.profiles = newProfiles
++        } catch {
++            print("An error occurred while loading profiles: \(error)")
++        }
++    }
++
++    public func loadProfile(profile: Profile, completion: @escaping (LoadProfileResult) -> Void) {
++        if(therapySettings.glucoseTargetRangeSchedule == profile.correctionRange &&
++           therapySettings.carbRatioSchedule == profile.carbRatioSchedule &&
++           therapySettings.basalRateSchedule == profile.basalRateSchedule &&
++           therapySettings.insulinSensitivitySchedule == profile.insulinSensitivitySchedule) {
++            self.setCurrentProfile(name: profile.name, syncChange: true)
++            completion(.success)
++        }
++        else
++        {
++            do {
++                delegate?.syncBasalRateSchedule(items: profile.basalRateSchedule.items, completion: { [weak self] result in
++                    switch result {
++                    case .success(let syncedSchedule):
++                        DispatchQueue.main.async {
++                            let unit = self?.therapySettings.glucoseTargetRangeSchedule?.unit ?? HKUnit.milligramsPerDeciliter
++                            self?.saveCorrectionRange(range: profile.correctionRange.schedule(for: unit)! )
++                            self?.saveCarbRatioSchedule(carbRatioSchedule: profile.carbRatioSchedule)
++                            self?.saveBasalRates(basalRates: syncedSchedule)
++                            self?.saveInsulinSensitivitySchedule(insulinSensitivitySchedule: profile.insulinSensitivitySchedule.schedule(for: unit)!)
++                            print("New profile loaded")
++                            self?.setCurrentProfile(name: profile.name, syncChange: false)
++                            completion(.success)
++                        }
++                    case .failure(let error):
++                        print("An error occurred while syncing basal rates: \(error)")
++                        completion(.failure(error))
++                    }
++                })
++            }
++        }
++    }
++
++    func getProfileReference(withName name: String) -> ProfileReference? {
++        let sanitizedInputName = sanitizeProfileName(name)
++        return profiles.first(where: { sanitizeProfileName($0.name) == sanitizedInputName })
++    }
++
++    public func removeProfile(profile: Profile) {
++        guard let profileReference = getProfileReference(withName: profile.name) else {
++            print("No ProfileReference found for given Profile")
++            return
++        }
++
++        removeProfile(profileReference: profileReference)
++        if getCurrentProfileName() == profile.name {
++            clearCurrentProfile()
++        }
++    }
++
++    public func removeProfile(profileReference: ProfileReference) {
++        do {
++            let fileManager = FileManager.default
++            let fileURL = profilesDirectory.appendingPathComponent(profileReference.fileName)
++            try fileManager.removeItem(at: fileURL)
++            loadProfiles()
++        } catch {
++            print("An error occurred while removing profile: \(error)")
++        }
++    }
++
++    func doesProfileExist(withName name: String) -> Bool {
++        return profiles.contains(where: { $0.name == name })
++    }
++
++    public func getProfile(from profileReference: ProfileReference) throws -> Profile {
++        let fileURL = profilesDirectory.appendingPathComponent(profileReference.fileName)
++        let data = try Data(contentsOf: fileURL)
++        let getProfile = try decodeProfile(from: data)
++        return getProfile
++    }
++
++    public func validateProfile(_ profile: Profile) -> Result<Void, ProfileValidationError> {
++        guard let supportedIncrements = delegate?.pumpSupportedIncrements() else {
++            return .failure(.fileLoadError)
++        }
++
++        // Checking Correction Range Schedule
++        for item in profile.correctionRange.items {
++            let minValue = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: item.value.minValue)
++            let maxValue = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: item.value.maxValue)
++
++            if !(Guardrail.correctionRange.absoluteBounds.contains(minValue) && Guardrail.correctionRange.absoluteBounds.contains(maxValue)) {
++                return .failure(.correctionRangeError)
++            }
++        }
++
++        // Checking Insulin Sensitivity Schedule
++        for item in profile.insulinSensitivitySchedule.items {
++            let value = HKQuantity(unit: HKUnit.milligramsPerDeciliter.unitDivided(by: .internationalUnit()), doubleValue: item.value)
++
++            if !Guardrail.insulinSensitivity.absoluteBounds.contains(value) {
++                return .failure(.insulinSensitivityError)
++            }
++        }
++
++        // Checking Carb Ratio Schedule
++        for item in profile.carbRatioSchedule.items {
++            let value = HKQuantity(unit: .gramsPerUnit, doubleValue: item.value)
++
++            if !Guardrail.carbRatio.absoluteBounds.contains(value) {
++                return .failure(.carbRatioError)
++            }
++        }
++
++        // Checking Basal Rate Schedule
++        if let maximumBasalRate = therapySettings.maximumBasalRatePerHour {
++            for item in profile.basalRateSchedule.items {
++                let value = item.value
++
++                if value > maximumBasalRate || !supportedIncrements.basalRates.contains(value) {
++                    return .failure(.basalRateError)
++                }
++            }
++        } else {
++            return .failure(.maxBasalRateNotSet)
++        }
++
++        return .success(())
++    }
++
++    func isCorrectionRangeEqual(a: GlucoseRangeSchedule, b: GlucoseRangeSchedule) -> Bool {
++        guard a.items.count == b.items.count else {
++            return false
++        }
++        
++        for (item1, item2) in zip(a.items, b.items) {
++            if item1.startTime != item2.startTime ||
++                abs(item1.value.minValue - item2.value.minValue) > 0.01 ||
++                abs(item1.value.maxValue - item2.value.maxValue) > 0.01 {
++                return false
++            }
++        }
++        
++        return true
++    }
++    
++    func isInsulinSensitivityScheduleEqual(a: InsulinSensitivitySchedule, b: InsulinSensitivitySchedule) -> Bool {
++        guard a.items.count == b.items.count else {
++            return false
++        }
++        
++        for (item1, item2) in zip(a.items, b.items) {
++            if item1.startTime != item2.startTime ||
++                abs(item1.value - item2.value) > 0.01 {
++                return false
++            }
++        }
++        
++        return true
++    }
++    
++    public func isCurrentProfileOutOfSync() -> Bool {
++        guard let currentProfileName = self.currentProfileName,
++              let currentProfileReference = profiles.first(where: { $0.name == currentProfileName }),
++              let profile = try? getProfile(from: currentProfileReference),
++              let therapyGlucoseSchedule = therapySettings.glucoseTargetRangeSchedule?.schedule(for: HKUnit.milligramsPerDeciliter),
++              let therapyInsulinSensitivitySchedule = therapySettings.insulinSensitivitySchedule?.schedule(for: HKUnit.milligramsPerDeciliter) else {
++            return false // No current profile set or profile not found or schedules not available
++        }
++        
++        var isOutOfSync = false
++        
++        if !isCorrectionRangeEqual(a: therapyGlucoseSchedule, b: profile.correctionRange.schedule(for: HKUnit.milligramsPerDeciliter)!) {
++            print("Glucose target range schedule differs")
++            isOutOfSync = true
++        }
++        if therapySettings.carbRatioSchedule != profile.carbRatioSchedule {
++            print("Carb ratio schedule differs")
++            isOutOfSync = true
++        }
++        if therapySettings.basalRateSchedule != profile.basalRateSchedule {
++            print("Basal rate schedule differs")
++            isOutOfSync = true
++        }
++        if !isInsulinSensitivityScheduleEqual(a: therapyInsulinSensitivitySchedule, b: profile.insulinSensitivitySchedule.schedule(for: HKUnit.milligramsPerDeciliter)!) {
++            print("Insulin sensitivity schedule differs")
++            isOutOfSync = true
++        }
++        
++        return isOutOfSync
++    }
++}
+diff --git a/LoopKit/LoopKitUI/ViewModels/ProfileViewModel.swift b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel.swift
+new file mode 100644
+index 0000000..a48fa66
+--- /dev/null
++++ b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel.swift
+@@ -0,0 +1,86 @@
++//
++//  ProfileViewModel.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2023-04-22.
++//  Copyright © 2023 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import Combine
++import LoopKit
++import HealthKit
++import SwiftUI
++
++public class ProfileViewModel: ObservableObject {
++    
++    @Published public var therapySettings: TherapySettings
++    @Published public var profiles = [ProfileReference]()
++    @Published public var currentProfileName: String? {
++        didSet {
++            UserDefaults.standard.setValue(currentProfileName, forKey: "currentProfileName")
++        }
++    }
++
++    internal weak var delegate: TherapySettingsViewModelDelegate?
++    
++    public init(therapySettings: TherapySettings,
++                pumpSupportedIncrements: (() -> PumpSupportedIncrements?)? = nil,
++                sensitivityOverridesEnabled: Bool = false,
++                adultChildInsulinModelSelectionEnabled: Bool = false,
++                prescription: Prescription? = nil,
++                delegate: TherapySettingsViewModelDelegate? = nil) {
++        self.therapySettings = therapySettings
++        self.delegate = delegate
++        self.currentProfileName = UserDefaults.standard.string(forKey: "currentProfileName")
++        self.loadProfiles()
++    }
++    
++    public func pumpSupportedIncrements() -> PumpSupportedIncrements? {
++        return delegate?.pumpSupportedIncrements()
++    }
++}
++
++public struct Profile: Codable {
++    let name: String
++    let correctionRange: GlucoseRangeSchedule
++    let carbRatioSchedule: CarbRatioSchedule
++    let basalRateSchedule: BasalRateSchedule
++    let insulinSensitivitySchedule: InsulinSensitivitySchedule
++    var sortOrder: Int?
++}
++
++public struct ProfileReference: Codable, Equatable {
++    var name: String
++    var fileName: String
++    var sortOrder: Int?
++}
++
++
++// MARK: Saving
++extension ProfileViewModel {
++    
++    public func saveCorrectionRange(range: GlucoseRangeSchedule) {
++        therapySettings.glucoseTargetRangeSchedule = range
++        delegate?.saveCompletion(therapySettings: therapySettings)
++    }
++    
++    public func saveBasalRates(basalRates: BasalRateSchedule) {
++        therapySettings.basalRateSchedule = basalRates
++        delegate?.saveCompletion(therapySettings: therapySettings)
++    }
++    
++    public func saveCarbRatioSchedule(carbRatioSchedule: CarbRatioSchedule) {
++        therapySettings.carbRatioSchedule = carbRatioSchedule
++        delegate?.saveCompletion(therapySettings: therapySettings)
++    }
++    
++    public func saveInsulinSensitivitySchedule(insulinSensitivitySchedule: InsulinSensitivitySchedule) {
++        therapySettings.insulinSensitivitySchedule = insulinSensitivitySchedule
++        delegate?.saveCompletion(therapySettings: therapySettings)
++    }
++
++    public func triggerProfileSync() {
++        delegate?.updateCurrentProfileName()
++    }
++}
+diff --git a/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift b/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
+index 3650ef6..c5c1dc0 100644
+--- a/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
++++ b/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
+@@ -16,6 +16,7 @@ public protocol TherapySettingsViewModelDelegate: AnyObject {
+     func syncDeliveryLimits(deliveryLimits: DeliveryLimits, completion: @escaping (Result<DeliveryLimits, Error>) -> Void)
+     func saveCompletion(therapySettings: TherapySettings)
+     func pumpSupportedIncrements() -> PumpSupportedIncrements?
++    func updateCurrentProfileName()
+ }
+ 
+ public class TherapySettingsViewModel: ObservableObject {
+diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/NewProfileEditor.swift b/LoopKit/LoopKitUI/Views/Settings Editors/NewProfileEditor.swift
+new file mode 100644
+index 0000000..446910e
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/Settings Editors/NewProfileEditor.swift	
+@@ -0,0 +1,79 @@
++//
++//  NewProfileEditor.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2023-05-19.
++//  Copyright © 2023 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import SwiftUI
++
++struct NewProfileEditor: View {
++    @Binding var isPresented: Bool
++    @State var newProfileName: String
++    var viewModel: ProfileViewModel
++    @State private var showAlert = false
++
++    var body: some View {
++        VStack(spacing: 0) {
++            ModalHeaderButtonBar(
++                leading: { cancelButton },
++                center: {
++                    Text("New Profile")
++                        .font(.headline)
++                },
++                trailing: { addButton }
++            )
++
++            TextField("Profile Name", text: $newProfileName)
++                .textFieldStyle(RoundedBorderTextFieldStyle())
++                .padding()
++                .background(
++                    RoundedCorners(radius: 10, corners: [.bottomLeft, .bottomRight])
++                        .fill(Color(.secondarySystemGroupedBackground))
++                )
++        }
++        .padding(.horizontal)
++        .alert(isPresented: $showAlert) {
++            Alert(
++                title: Text("Overwrite Existing Profile"),
++                message: Text("A profile with this name already exists. Would you like to overwrite it?"),
++                primaryButton: .destructive(Text("Overwrite")) {
++                    self.viewModel.saveProfile(withName: self.newProfileName)
++                    self.isPresented = false
++                },
++                secondaryButton: .cancel()
++            )
++        }
++    }
++
++    var addButton: some View {
++        Button(
++            action: {
++                withAnimation {
++                    if viewModel.doesProfileExist(withName: self.newProfileName) {
++                        self.showAlert = true
++                    } else {
++                        self.viewModel.saveProfile(withName: self.newProfileName)
++                        self.isPresented = false
++                    }
++                }
++            }, label: {
++                Text("Add")
++            }
++        )
++    }
++
++    var cancelButton: some View {
++        Button(
++            action: {
++                withAnimation {
++                    self.isPresented = false
++                }
++            }, label: {
++                Text("Cancel")
++            }
++        )
++    }
++}
+diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/ProfilePreviewView.swift b/LoopKit/LoopKitUI/Views/Settings Editors/ProfilePreviewView.swift
+new file mode 100644
+index 0000000..6de3598
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/Settings Editors/ProfilePreviewView.swift	
+@@ -0,0 +1,326 @@
++//
++//  ProfilePreviewView.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2023-05-23.
++//  Copyright © 2023 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import SwiftUI
++import HealthKit
++import LoopKit
++
++enum ActiveAlert {
++    case load
++    case delete
++    case error
++}
++
++struct ProfilePreviewView: View {
++    @EnvironmentObject private var displayGlucosePreference: DisplayGlucosePreference
++    @ObservedObject var viewModel: ProfileViewModel
++    @Environment(\.dismissAction) var dismissAction
++    @Environment(\.presentationMode) var presentationMode
++    var profile: Profile
++
++    @State private var showingAlert = false
++    @State private var activeAlert: ActiveAlert = .load
++    @State private var errorText: String?
++    @State private var newProfileName: String = ""
++    @State private var isRenamingProfile = false
++    @State private var shouldDismissSelf: Bool = false
++
++    let nilDestination: (_ dismiss: @escaping () -> Void) -> AnyView = { _ in AnyView(EmptyView()) }
++
++    var body: some View {
++        ZStack {
++            ScrollView {
++                VStack(alignment: .leading) {
++                    Text("Before proceeding, review the profile details below. Scroll to find options to Load, Rename, or Delete.")
++                        .font(.body)
++                        .foregroundColor(.primary)
++                        .padding([.leading, .trailing])
++                        .fixedSize(horizontal: false, vertical: true)
++                        .textCase(nil)
++                    
++                    profileCardStack
++                    
++                    Button(action: {
++                        activeAlert = .load
++                        showingAlert = true
++                    }) {
++                        HStack {
++                            Spacer()
++                            Text("Load")
++                                .foregroundColor(.white)
++                                .padding()
++                            Spacer()
++                        }
++                    }
++                    .background(Color.blue)
++                    .cornerRadius(10)
++                    .padding(.horizontal)
++                    
++                    Button(action: {
++                        isRenamingProfile = true
++                    }) {
++                        HStack {
++                            Spacer()
++                            Text("Rename")
++                                .foregroundColor(.white)
++                                .padding()
++                            Spacer()
++                        }
++                    }
++                    .background(Color.orange)
++                    .cornerRadius(10)
++                    .padding(.horizontal)
++                    
++                    Button(action: {
++                        activeAlert = .delete
++                        showingAlert = true
++                    }) {
++                        HStack {
++                            Spacer()
++                            Text("Delete")
++                                .foregroundColor(.white)
++                                .padding()
++                            Spacer()
++                        }
++                    }
++                    .background(Color.red)
++                    .cornerRadius(10)
++                    .padding(.horizontal)
++                    
++                }
++            }
++            .navigationBarHidden(false)
++            .background(Color(.systemGroupedBackground))
++            .navigationTitle(Text(profile.name))
++            .alert(isPresented: $showingAlert) {
++                switch activeAlert {
++                case .load:
++                    return Alert(
++                        title: Text("Load Profile"),
++                        message: Text("Do you want to load the profile \(profile.name)?"),
++                        primaryButton: .default(Text("Yes"), action: {
++                            let validationResult = viewModel.validateProfile(profile)
++                            switch validationResult {
++                            case .success:
++                                viewModel.loadProfile(profile: profile) { result in
++                                    switch result {
++                                    case .success:
++                                        dismissAction()
++                                    case .failure(let error):
++                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
++                                            self.errorText = error.localizedDescription
++                                            self.activeAlert = .error
++                                            self.showingAlert = true
++                                        }
++                                    }
++                                }
++                            case .failure(let error):
++                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
++                                    self.errorText = error.localizedDescription
++                                    self.activeAlert = .error
++                                    self.showingAlert = true
++                                }
++                            }
++                        }),
++                        secondaryButton: .cancel()
++                    )
++                case .delete:
++                    return Alert(
++                        title: Text("Delete Profile"),
++                        message: Text("Are you sure you want to delete the profile \(profile.name)? This action cannot be undone."),
++                        primaryButton: .destructive(Text("Delete"), action: {
++                            viewModel.removeProfile(profile: profile)
++                            self.presentationMode.wrappedValue.dismiss()
++                        }),
++                        secondaryButton: .cancel()
++                    )
++                case .error:
++                    return Alert(
++                        title: Text("Error loading profile"),
++                        message: Text(errorText ?? "Unknown error"),
++                        dismissButton: .default(Text("OK"))
++                    )
++                }
++            }
++            if isRenamingProfile {
++                // Some hacks here to mimic Alert behaviour.
++                // This function should be migrateed to Alert when iOS 16 is required.
++                Color.black.opacity(0.5)
++                    .edgesIgnoringSafeArea(.all)
++                    .onTapGesture {
++                        isRenamingProfile = false
++                    }
++                
++                RenameProfileEditor(
++                    isPresented: $isRenamingProfile,
++                    currentProfileName: profile.name,
++                    viewModel: viewModel,
++                    shouldDismissParent: $shouldDismissSelf
++                )
++                .transition(AnyTransition.move(edge: .bottom).combined(with: .opacity).animation(.default))
++                .offset(y: -22)
++            }
++        }
++        .onChange(of: shouldDismissSelf) { shouldDismiss in
++            if shouldDismiss {
++                self.presentationMode.wrappedValue.dismiss()
++            }
++        }
++    }
++
++    private var profileCardStack: CardStack {
++        var cards: [Card] = []
++
++        cards.append(correctionRangeSection)
++        cards.append(carbRatioSection)
++        cards.append(basalRatesSection)
++        cards.append(insulinSensitivitiesSection)
++
++        return CardStack(cards: cards)
++    }
++
++    private var correctionRangeSection: Card {
++        card(for: .glucoseTargetRange) {
++            if let items = profile.correctionRange.schedule(for: glucoseUnit)?.items {
++                SectionDivider()
++                ForEach(items.indices, id: \.self) { index in
++                    if index > 0 {
++                        SettingsDivider()
++                    }
++
++                    ScheduleRangeItem(time: items[index].startTime,
++                                      range: items[index].value,
++                                      unit: glucoseUnit,
++                                      guardrail: .correctionRange)
++                }
++            }
++        }
++    }
++
++    private var carbRatioSection: Card {
++        card(for: .carbRatio) {
++            SectionDivider()
++            let items = profile.carbRatioSchedule.items
++            ForEach(items.indices, id: \.self) { index in
++                if index > 0 {
++                    SettingsDivider()
++                }
++
++                ScheduleValueItem(time: items[index].startTime,
++                                  value: items[index].value,
++                                  unit: .gramsPerUnit,
++                                  guardrail: .carbRatio)
++            }
++        }
++    }
++
++    private var basalRatesSection: Card {
++        card(for: .basalRate) {
++            let items = profile.basalRateSchedule.items
++            if let supportedBasalRates = viewModel.pumpSupportedIncrements()?.basalRates
++            {
++                SectionDivider()
++                let total = profile.basalRateSchedule.total()
++                ForEach(items.indices, id: \.self) { index in
++                    if index > 0 {
++                        SettingsDivider()
++                    }
++
++                    ScheduleValueItem(time: items[index].startTime,
++                                      value:  items[index].value,
++                                      unit: .internationalUnitsPerHour,
++                                      guardrail: .basalRate(supportedBasalRates: supportedBasalRates))
++                }
++                HStack {
++                    Text("Total")
++                        .bold()
++                        .foregroundColor(.primary)
++                    Spacer()
++                    Text(String(format: "%.2f ",total))
++                        .foregroundColor(.primary) +
++                    Text("U/day")
++                        .foregroundColor(.secondary)
++                }
++            }
++        }
++    }
++
++    private var insulinSensitivitiesSection: Card {
++        card(for: .insulinSensitivity) {
++            if let items = profile.insulinSensitivitySchedule.schedule(for: glucoseUnit)?.items
++            {
++                SectionDivider()
++                ForEach(items.indices, id: \.self) { index in
++                    if index > 0 {
++                        SettingsDivider()
++                    }
++                    ScheduleValueItem(time: items[index].startTime,
++                                      value: items[index].value,
++                                      unit: sensitivityUnit,
++                                      guardrail: .insulinSensitivity)
++                }
++            }
++        }
++    }
++}
++
++
++struct SectionWithContent<Content>: View where Content: View {
++    let title: String
++    let content: Content
++
++    init(title: String,
++         content: () -> Content)
++    {
++        self.title = title
++        self.content = content()
++    }
++
++    public var body: some View {
++        Section {
++            Text(title)
++                .bold()
++                .frame(maxWidth: .infinity, alignment: .leading)
++            content
++        }
++    }
++}
++
++// MARK: Utilities
++extension ProfilePreviewView {
++
++    private var glucoseUnit: HKUnit {
++        displayGlucosePreference.unit
++    }
++
++    private var sensitivityUnit: HKUnit {
++        glucoseUnit.unitDivided(by: .internationalUnit())
++    }
++
++    private func card<Content>(for therapySetting: TherapySetting, @ViewBuilder content: @escaping () -> Content) -> Card where Content: View {
++        Card {
++            SectionWithContent(title: therapySetting.title,
++                               content: content)
++        }
++    }
++}
++
++fileprivate struct SectionDivider: View {
++    var body: some View {
++        Divider()
++            .padding(.trailing, -16)
++    }
++}
++
++fileprivate struct SettingsDivider: View {
++    var body: some View {
++        Divider()
++            .padding(.trailing, -8)
++    }
++}
+diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/ProfileView.swift b/LoopKit/LoopKitUI/Views/Settings Editors/ProfileView.swift
+new file mode 100644
+index 0000000..1c6244a
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/Settings Editors/ProfileView.swift	
+@@ -0,0 +1,173 @@
++//
++//  ProfileView.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2023-04-22.
++//  Copyright © 2023 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import AVFoundation
++import HealthKit
++import LoopKit
++import SwiftUI
++
++public struct ProfileView: View {
++    @ObservedObject public var viewModel: ProfileViewModel
++    @Environment(\.dismissAction) var dismissAction
++    @State private var newProfileName: String = ""
++    @State private var isAddingNewProfile = false
++    @State private var selectedProfileIndex: Int? = nil
++    @State private var refreshID = UUID()
++
++    enum ActiveAlert: String, Identifiable {
++        case update, info
++        
++        var id: String {
++            return self.rawValue
++        }
++    }
++    @State private var activeAlert: ActiveAlert?
++    
++    public init(viewModel: ProfileViewModel) {
++        self.viewModel = viewModel
++    }
++    
++    private var dismissButton: some View {
++        Button(action: dismissAction) {
++            Text(LocalizedString("Done", comment: "Text for dismiss button"))
++                .bold()
++        }
++    }
++    
++    public var body: some View {
++        ZStack {
++            NavigationView {
++                ConfigurationPageScrollView(
++                    content: {
++                        VStack(alignment: .leading) {
++                            
++                            if !viewModel.profiles.isEmpty {
++                                List {
++                                    ForEach(viewModel.profiles.indices, id: \.self) { index in
++                                        if let profile = try? viewModel.getProfile(from: viewModel.profiles[index]) {
++                                            NavigationLink(destination: ProfilePreviewView(viewModel: viewModel, profile: profile)) {
++                                                HStack {
++                                                    if viewModel.currentProfileName == viewModel.profiles[index].name {
++                                                        Image(systemName: "checkmark")
++                                                            .foregroundColor(Color.blue)
++                                                    } else {
++                                                        // Add indentation to align with the checkmark for the active profile
++                                                        Image(systemName: "checkmark")
++                                                            .opacity(0) // Invisible
++                                                    }
++                                                    
++                                                    Text(viewModel.profiles[index].name)
++                                                }
++                                            }
++                                        }
++                                    }
++                                    .onMove(perform: moveProfile)
++                                }.id(refreshID)
++                                
++                            } else {
++                                Text("Use ‘+’ to create a new profile capturing your glucose targets, carb ratios, basal rates, and insulin sensitivities.")
++                                    .font(.subheadline)
++                                    .foregroundColor(.secondary)
++                                    .padding([.leading, .trailing])
++                                    .multilineTextAlignment(.leading)
++                                    .lineLimit(nil)
++                                    .textCase(nil)
++                            }
++                        }
++                    },
++                    actionArea: { EmptyView() } // no action area in this case
++                )
++                .navigationBarItems(
++                    leading: HStack {
++                        Button(action: { withAnimation { isAddingNewProfile = true } }) {
++                            Image(systemName: "plus")
++                        }
++                        
++                        Button(action: { activeAlert = .info }) {
++                            Image(systemName: "info.circle")
++                                .resizable()
++                                .frame(width: 24, height: 24)
++                        }
++                    },
++                    trailing: dismissButton
++                )
++                .navigationTitle(Text(LocalizedString("Profiles", comment: "Title on ProfileView")))
++            }
++            .navigationBarHidden(false)
++            .background(Color(.systemGroupedBackground))
++            .onAppear {
++                if viewModel.isCurrentProfileOutOfSync() {
++                    activeAlert = .update
++                }
++            }
++            
++            .alert(item: $activeAlert) { alertType in
++                switch alertType {
++                case .update:
++                    return Alert(
++                        title: Text("Profile Outdated"),
++                        message: Text("The current therapy settings have changed. Do you want to update the profile named: \(viewModel.currentProfileName ?? "")?"),
++                        primaryButton: .default(Text("Update")) {
++                            viewModel.saveProfile(withName: viewModel.currentProfileName ?? "")
++                        },
++                        secondaryButton: .cancel()
++                    )
++                case .info:
++                    return Alert(title: Text("Information"),
++                                 message: Text("A checkmark next to a profile name indicates that it's the active one.\n\nUse ‘+’ to create a new profile capturing your glucose targets, carb ratios, basal rates, and insulin sensitivities.\n\nTap on any profile to review its settings in detail. In detail view, you can Load, Rename or Delete that particular profile.\n\nWant to change the order of profiles? Simply press and hold on a profile, then drag it to your desired position."),
++                                 dismissButton: .default(Text("Got it!")))
++                }
++            }
++            
++            if isAddingNewProfile {
++                DarkenedOverlay()
++                
++                NewProfileEditor(
++                    isPresented: $isAddingNewProfile,
++                    newProfileName: newProfileName,
++                    viewModel: viewModel
++                )
++                .transition(AnyTransition.move(edge: .bottom).combined(with: .opacity).animation(.default))
++            }
++        }
++    }
++    
++    func moveProfile(from source: IndexSet, to destination: Int) {
++        viewModel.profiles.move(fromOffsets: source, toOffset: destination)
++        refreshID = UUID()
++        viewModel.updateProfilesOrder()
++    }
++}
++
++struct ProfileView_Previews: PreviewProvider {
++    static let preview_glucoseScheduleItems = [
++        RepeatingScheduleValue(startTime: 0, value: DoubleRange(80...90)),
++        RepeatingScheduleValue(startTime: 1800, value: DoubleRange(90...100)),
++        RepeatingScheduleValue(startTime: 3600, value: DoubleRange(100...110))
++    ]
++    
++    static let preview_therapySettings = TherapySettings(
++        glucoseTargetRangeSchedule: GlucoseRangeSchedule(unit: .milligramsPerDeciliter, dailyItems: preview_glucoseScheduleItems),
++        correctionRangeOverrides: CorrectionRangeOverrides(preMeal: DoubleRange(88...99),
++                                                           workout: DoubleRange(99...111),
++                                                           unit: .milligramsPerDeciliter),
++        maximumBolus: 4,
++        suspendThreshold: GlucoseThreshold.init(unit: .milligramsPerDeciliter, value: 60),
++        insulinSensitivitySchedule: InsulinSensitivitySchedule(unit: HKUnit.milligramsPerDeciliter.unitDivided(by: HKUnit.internationalUnit()), dailyItems: []),
++        carbRatioSchedule: nil,
++        basalRateSchedule: BasalRateSchedule(dailyItems: [RepeatingScheduleValue(startTime: 0, value: 0.2), RepeatingScheduleValue(startTime: 1800, value: 0.75)]))
++    
++    static let preview_supportedBasalRates = [0.2, 0.5, 0.75, 1.0]
++    static let preview_supportedBolusVolumes = [1.0, 2.0, 3.0]
++    static let preview_supportedMaximumBolusVolumes = [5.0, 10.0, 15.0]
++    
++    static var previews: some View {
++        ProfileView(viewModel: ProfileViewModel(therapySettings: preview_therapySettings))
++    }
++}
+diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/RenameProfileEditor.swift b/LoopKit/LoopKitUI/Views/Settings Editors/RenameProfileEditor.swift
+new file mode 100644
+index 0000000..8fd2666
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/Settings Editors/RenameProfileEditor.swift	
+@@ -0,0 +1,92 @@
++//
++//  RenameProfileEditor.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2023-09-07.
++//  Copyright © 2023 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import SwiftUI
++
++struct RenameProfileEditor: View {
++    @Binding var isPresented: Bool
++    @State var currentProfileName: String
++    @State var newProfileName: String = ""
++    var viewModel: ProfileViewModel
++    @State private var showAlert = false
++    @Binding var shouldDismissParent: Bool
++
++    var body: some View {
++        VStack(spacing: 0) {
++            ModalHeaderButtonBar(
++                leading: { cancelButton },
++                center: {
++                    Text("Rename Profile")
++                        .font(.subheadline)
++
++                },
++                trailing: { renameButton }
++            )
++            .onAppear {
++                self.newProfileName = currentProfileName
++            }
++            
++            TextField("Profile Name", text: $newProfileName)
++                .textFieldStyle(RoundedBorderTextFieldStyle())
++                .padding()
++                .background(
++                    RoundedCorners(radius: 10, corners: [.bottomLeft, .bottomRight])
++                        .fill(Color(.secondarySystemGroupedBackground))
++                )
++        }
++        .padding(.horizontal)
++        .alert(isPresented: $showAlert) {
++            Alert(
++                title: Text("Overwrite Existing Profile"),
++                message: Text("A profile with this name already exists. Would you like to overwrite it?"),
++                primaryButton: .destructive(Text("Overwrite")) {
++                    self.viewModel.renameProfile(oldName: currentProfileName, newName: self.newProfileName)
++                    self.shouldDismissParent = true
++                    self.isPresented = false
++                },
++                secondaryButton: .cancel()
++            )
++        }
++    }
++    
++    var renameButton: some View {
++        Button(
++            action: {
++                withAnimation {
++                    guard newProfileName != currentProfileName else {
++                        self.isPresented = false
++                        return
++                    }
++
++                    if viewModel.doesProfileExist(withName: self.newProfileName) {
++                        self.showAlert = true
++                    } else {
++                        self.viewModel.renameProfile(oldName: currentProfileName, newName: self.newProfileName)
++                        self.shouldDismissParent = true
++                        self.isPresented = false
++                    }
++                }
++            }, label: {
++                Text("Rename")
++            }
++        )
++    }
++    
++    var cancelButton: some View {
++        Button(
++            action: {
++                withAnimation {
++                    self.isPresented = false
++                }
++            }, label: {
++                Text("Cancel")
++            }
++        )
++    }
++}
+Submodule LoopOnboarding 4c5c192..e15f085:
+diff --git a/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift b/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift
+index cc61f2d..6462e2c 100644
+--- a/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift	
++++ b/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift	
+@@ -379,6 +379,9 @@ extension OnboardingUICoordinator: TherapySettingsViewModelDelegate {
+             maximumBasalScheduleEntryCount: maximumBasalScheduleEntryCount
+         )
+     }
++    
++    func updateCurrentProfileName() {
++    }
+ }
+ 
+ 
+Submodule NightscoutService 9b2f2ae..2093122:
+diff --git a/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift b/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift
+index 0bed9c6..7d6c12d 100644
+--- a/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift
++++ b/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift
+@@ -94,12 +94,20 @@ extension StoredSettings {
+             return nil
+         }
+ 
++        var store = ["Default": profile]
++        var defaultProfile = "Default"
++
++        if let name = UserDefaults.standard.string(forKey: "currentProfileName") {
++            defaultProfile = name
++            store[name] = profile
++        }
++
+         return ProfileSet(
+             startDate: date,
+             units: bloodGlucoseUnit.shortLocalizedUnitString(avoidLineBreaking: false),
+             enteredBy: "Loop",
+-            defaultProfile: "Default",
+-            store: ["Default": profile],
++            defaultProfile: defaultProfile,
++            store: store,
+             settings: loopSettings,
+             syncIdentifier: syncIdentifier.uuidString)
+     }

--- a/profiles/dev377_profiles_basal_lock.patch
+++ b/profiles/dev377_profiles_basal_lock.patch
@@ -1,0 +1,1432 @@
+Submodule Loop 7b04dec..1a088f9:
+diff --git a/Loop/Loop/Managers/DeviceDataManager.swift b/Loop/Loop/Managers/DeviceDataManager.swift
+index 2751f18f..4866c85c 100644
+--- a/Loop/Loop/Managers/DeviceDataManager.swift
++++ b/Loop/Loop/Managers/DeviceDataManager.swift
+@@ -1636,6 +1636,10 @@ extension DeviceDataManager: TherapySettingsViewModelDelegate {
+         }
+     }
+     
++    func updateCurrentProfileName() {
++        loopManager.updateCurrentProfileName()
++    }
++    
+     func saveCompletion(therapySettings: TherapySettings) {
+ 
+         loopManager.mutateSettings { settings in
+diff --git a/Loop/Loop/Managers/LoopDataManager.swift b/Loop/Loop/Managers/LoopDataManager.swift
+index c3f0c422..f6accc52 100644
+--- a/Loop/Loop/Managers/LoopDataManager.swift
++++ b/Loop/Loop/Managers/LoopDataManager.swift
+@@ -229,6 +229,10 @@ final class LoopDataManager {
+         lockedSettings.value
+     }
+ 
++    func updateCurrentProfileName () {
++        notify(forChange: .preferences)
++    }
++    
+     func mutateSettings(_ changes: (_ settings: inout LoopSettings) -> Void) {
+         var oldValue: LoopSettings!
+         let newValue = lockedSettings.mutate { settings in
+diff --git a/Loop/Loop/Views/SettingsView.swift b/Loop/Loop/Views/SettingsView.swift
+index 60e36b9a..f2a41195 100644
+--- a/Loop/Loop/Views/SettingsView.swift
++++ b/Loop/Loop/Views/SettingsView.swift
+@@ -52,6 +52,7 @@ public struct SettingsView: View {
+             case favoriteFoods
+             case therapySettings
+             case preferences
++            case profiles
+         }
+     }
+     
+@@ -163,6 +164,19 @@ public struct SettingsView: View {
+                     FavoriteFoodsView()
+                 case .preferences:
+                     PreferencesView(viewModel: PreferencesViewModel(preferencesProvider: Preferences.shared)).environmentObject(displayGlucosePreference)
++                case .profiles:
++                    ProfileView(viewModel: ProfileViewModel(therapySettings: self.viewModel.therapySettings(),
++                                                            sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
++                                                            adultChildInsulinModelSelectionEnabled: FeatureFlags.adultChildInsulinModelSelectionEnabled,
++                                                            delegate: self.viewModel.therapySettingsViewModelDelegate))
++                    .environmentObject(displayGlucosePreference)
++                    .environment(\.dismissAction, self.dismiss)
++                    .environment(\.appName, self.appName)
++                    .environment(\.chartColorPalette, .primary)
++                    .environment(\.carbTintColor, self.carbTintColor)
++                    .environment(\.glucoseTintColor, self.glucoseTintColor)
++                    .environment(\.guidanceColors, self.guidanceColors)
++                    .environment(\.insulinTintColor, self.insulinTintColor)
+                 }
+             }
+         }
+@@ -300,7 +314,11 @@ extension SettingsView {
+                             imageView: Image("Therapy Icon"),
+                             label: NSLocalizedString("Therapy Settings", comment: "Title text for button to Therapy Settings"),
+                             descriptiveText: NSLocalizedString("Diabetes Treatment", comment: "Descriptive text for Therapy Settings"))
+-            
++            LargeButton(action: { sheet = .profiles },
++                        includeArrow: true,
++                        imageView: AnyView(Image(systemName: "arrow.triangle.2.circlepath").font(.system(size: 30, weight: .bold))),
++                        label: NSLocalizedString("Profiles", comment: "Title text for button to Profiles"),
++                        descriptiveText: NSLocalizedString("Switch between profiles for different scenarios", comment: "Descriptive text for Profiles"))
+             ForEach(pluginMenuItems.filter {$0.section == .configuration}) { item in
+                 item.view
+             }
+Submodule LoopKit 2254113..c213415:
+diff --git a/LoopKit/LoopKit.xcodeproj/project.pbxproj b/LoopKit/LoopKit.xcodeproj/project.pbxproj
+index 6e177b30..7ec12a27 100644
+--- a/LoopKit/LoopKit.xcodeproj/project.pbxproj
++++ b/LoopKit/LoopKit.xcodeproj/project.pbxproj
+@@ -863,6 +863,12 @@
+ 		C1FAEC1D264AD6B400A3250B /* DeviceStatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FAEC1C264AD6B400A3250B /* DeviceStatusBadge.swift */; };
+ 		C1FAEC1F264AE12700A3250B /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47ECF8725DC20810024A54D /* UIImage.swift */; };
+ 		C1FAEC21264AEEA300A3250B /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FAEC20264AEEA300A3250B /* UIImage.swift */; };
++		DD508E062A17712D00EEF8FD /* ProfileViewModel+FileManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD508E052A17712D00EEF8FD /* ProfileViewModel+FileManagement.swift */; };
++		DD508E082A17763700EEF8FD /* NewProfileEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD508E072A17763700EEF8FD /* NewProfileEditor.swift */; };
++		DD7122612A1D2AA4004FE653 /* ProfilePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7122602A1D2AA4004FE653 /* ProfilePreviewView.swift */; };
++		DDAF746729F422C600719F0A /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAF746629F422C600719F0A /* ProfileView.swift */; };
++		DDAF746929F4234000719F0A /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAF746829F4234000719F0A /* ProfileViewModel.swift */; };
++		DDCFC91E2AA9F702003DE656 /* RenameProfileEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCFC91D2AA9F702003DE656 /* RenameProfileEditor.swift */; };
+ 		DD13BC702C3C71A70062313B /* BasalLockEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD13BC6F2C3C71A70062313B /* BasalLockEditor.swift */; };
+ 		DD13BC722C3C74CD0062313B /* PreferencesGuardrailWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD13BC712C3C74CD0062313B /* PreferencesGuardrailWarning.swift */; };
+ 		DD28B3712B80C074001044D4 /* PreferencesSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD28B3702B80C074001044D4 /* PreferencesSetting.swift */; };
+@@ -1790,6 +1796,12 @@
+ 		C1FAC06228C7B0A100754AE2 /* reservoir_iob_test.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reservoir_iob_test.json; sourceTree = "<group>"; };
+ 		C1FAEC1C264AD6B400A3250B /* DeviceStatusBadge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceStatusBadge.swift; sourceTree = "<group>"; };
+ 		C1FAEC20264AEEA300A3250B /* UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
++		DD508E052A17712D00EEF8FD /* ProfileViewModel+FileManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfileViewModel+FileManagement.swift"; sourceTree = "<group>"; };
++		DD508E072A17763700EEF8FD /* NewProfileEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProfileEditor.swift; sourceTree = "<group>"; };
++		DD7122602A1D2AA4004FE653 /* ProfilePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePreviewView.swift; sourceTree = "<group>"; };
++		DDAF746629F422C600719F0A /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
++		DDAF746829F4234000719F0A /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
++		DDCFC91D2AA9F702003DE656 /* RenameProfileEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameProfileEditor.swift; sourceTree = "<group>"; };
+ 		DD13BC6F2C3C71A70062313B /* BasalLockEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasalLockEditor.swift; sourceTree = "<group>"; };
+ 		DD13BC712C3C74CD0062313B /* PreferencesGuardrailWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesGuardrailWarning.swift; sourceTree = "<group>"; };
+ 		DD28B3702B80C074001044D4 /* PreferencesSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesSetting.swift; sourceTree = "<group>"; };
+@@ -3182,12 +3194,14 @@
+ 			isa = PBXGroup;
+ 			children = (
+ 				B455F3A325FF7FF0000ED456 /* CorrectionRangeOverridesEditorViewModel.swift */,
++				DDAF746829F4234000719F0A /* ProfileViewModel.swift */,
+ 				B4B7C1BB2604E3FC007379F6 /* CorrectionRangeScheduleEditorViewModel.swift */,
+ 				B4D4C20C25F95A8700DA809D /* DisplayGlucosePreference.swift */,
+ 				B455F48025FF9A8B000ED456 /* InsulinSensitivityScheduleEditorViewModel.swift */,
+ 				B455F2A125FBE985000ED456 /* SuspendThresholdEditorViewModel.swift */,
+ 				1D1FCE2424BD42EF000300A8 /* TherapySettingsViewModel.swift */,
+ 				DD545A5E2B80EFA900915F95 /* PreferencesViewModel.swift */,
++				DD508E052A17712D00EEF8FD /* ProfileViewModel+FileManagement.swift */,
+ 			);
+ 			path = ViewModels;
+ 			sourceTree = "<group>";
+@@ -3384,6 +3398,10 @@
+ 				E96DCB5924AF74AC007117BC /* SuspendThresholdEditor.swift */,
+ 				1D1FCE2A24BE704A000300A8 /* TherapySetting+Settings.swift */,
+ 				1D1A019D24B678BF0077D86E /* TherapySettingsView.swift */,
++				DDAF746629F422C600719F0A /* ProfileView.swift */,
++				DD508E072A17763700EEF8FD /* NewProfileEditor.swift */,
++				DD7122602A1D2AA4004FE653 /* ProfilePreviewView.swift */,
++				DDCFC91D2AA9F702003DE656 /* RenameProfileEditor.swift */,
+ 			);
+ 			path = "Settings Editors";
+ 			sourceTree = "<group>";
+@@ -4089,6 +4107,7 @@
+ 				E9086B4824B5405E0062F5C8 /* ChartAxisValueDoubleUnit.swift in Sources */,
+ 				B429D66C24BF7204003E1B4A /* GlucoseTrend.swift in Sources */,
+ 				432CF86720D76AB90066B889 /* SettingsTableViewCell.swift in Sources */,
++				DD508E082A17763700EEF8FD /* NewProfileEditor.swift in Sources */,
+ 				898B4E7B246DC6A70053C484 /* CorrectionRangeScheduleEditor.swift in Sources */,
+ 				E9E5E56A24D5CCE800B5DFFE /* OverrideViewCell.swift in Sources */,
+ 				892A5DB42231E191008961AB /* LevelMaskView.swift in Sources */,
+@@ -4098,6 +4117,7 @@
+ 				B43D69D62A26642300DF0925 /* DemoPlaceHolderView.swift in Sources */,
+ 				E949E38F24B3711E00024DA0 /* InsulinModelInformationView.swift in Sources */,
+ 				895FE08B22011F0C00FCF18A /* EmojiInputHeaderView.swift in Sources */,
++				DDCFC91E2AA9F702003DE656 /* RenameProfileEditor.swift in Sources */,
+ 				895FE08322011F0C00FCF18A /* OverrideSelectionFooterView.swift in Sources */,
+ 				89AF78C22447E353002B4FCC /* Splat.swift in Sources */,
+ 				893C9F8C2447DBD900CD4185 /* CardBuilder.swift in Sources */,
+@@ -4149,9 +4169,11 @@
+ 				E9C58A6E24DA65E400487A17 /* HistoricalOverrideDetailView.swift in Sources */,
+ 				895FE08222011F0C00FCF18A /* LabeledTextFieldTableViewCell.swift in Sources */,
+ 				B43DA44224D9CD8500CAFF4E /* Environment+Colors.swift in Sources */,
++				DD508E062A17712D00EEF8FD /* ProfileViewModel+FileManagement.swift in Sources */,
+ 				892A5DB22231E191008961AB /* LoadingTableViewCell.swift in Sources */,
+ 				B4D3D4AD25B8A94E0085BA0F /* DisplayGlucoseUnitObserver.swift in Sources */,
+ 				A9D3FF102A6C19CA000C891D /* ChartAxisValueDoubleLog.swift in Sources */,
++				DD7122612A1D2AA4004FE653 /* ProfilePreviewView.swift in Sources */,
+ 				E96DCB5A24AF74AC007117BC /* SuspendThresholdEditor.swift in Sources */,
+ 				E96DCB5824AEF50F007117BC /* SuspendThresholdInformationView.swift in Sources */,
+ 				A9D3FF0C2A6C198C000C891D /* CollectionType.swift in Sources */,
+@@ -4228,6 +4250,7 @@
+ 				E93C86B624D08CAD0073089B /* InsulinSensitivityInformationView.swift in Sources */,
+ 				C18733AF29B9492300519CDF /* Collection.swift in Sources */,
+ 				892A5DA22231E137008961AB /* HUDProvider.swift in Sources */,
++				DDAF746929F4234000719F0A /* ProfileViewModel.swift in Sources */,
+ 				898E6E6C224194060019E459 /* UIColor.swift in Sources */,
+ 				43BA717D201EE7090058961E /* GlucoseRangeTableViewCell.swift in Sources */,
+ 				B455F3A425FF7FF0000ED456 /* CorrectionRangeOverridesEditorViewModel.swift in Sources */,
+@@ -4255,6 +4278,7 @@
+ 				1D1065E9282DC54700026A70 /* VideoPlayView.swift in Sources */,
+ 				E99A132E2557548300D3F5B3 /* SegmentedGaugeBar.swift in Sources */,
+ 				B455F31825FBEC5F000ED456 /* SuspendThresholdEditorViewModel.swift in Sources */,
++				DDAF746729F422C600719F0A /* ProfileView.swift in Sources */,
+ 				892A5DB32231E191008961AB /* LevelHUDView.swift in Sources */,
+ 				B41A60B223D1DBC700636320 /* UIFont.swift in Sources */,
+ 				B41A60AF23D1DB5B00636320 /* TableViewTitleLabel.swift in Sources */,
+diff --git a/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
+new file mode 100644
+index 00000000..74724fb7
+--- /dev/null
++++ b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel+FileManagement.swift
+@@ -0,0 +1,408 @@
++//
++//  ProfileViewModel+FileManagement.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2023-05-19.
++//  Copyright © 2023 LoopKit Authors. All rights reserved.
++//
++
++import LoopKit
++import HealthKit
++
++public enum ProfileValidationError: Error, LocalizedError {
++    case fileLoadError
++    case unsupportedIncrement
++    case correctionRangeError
++    case insulinSensitivityError
++    case carbRatioError
++    case basalRateError
++    case maxBasalRateNotSet
++
++    public var errorDescription: String? {
++        switch self {
++        case .fileLoadError:
++            return "Unable to load the profile file."
++        case .unsupportedIncrement:
++            return "The profile contains unsupported increments."
++        case .correctionRangeError:
++            return "Correction Range values are out of bounds."
++        case .insulinSensitivityError:
++            return "Insulin Sensitivity values are out of bounds."
++        case .carbRatioError:
++            return "Carb Ratio values are out of bounds."
++        case .basalRateError:
++            return "Basal Rate values are out of bounds."
++        case .maxBasalRateNotSet:
++            return "Maximum Basal Rate is not set."
++        }
++    }
++}
++
++public enum LoadProfileResult {
++    case success
++    case failure(Error)
++}
++
++// MARK: File management
++extension ProfileViewModel {
++    private func setCurrentProfile(name: String, syncChange: Bool = false) {
++        let sanitizedProfileName = sanitizeProfileName(name)
++        currentProfileName = sanitizedProfileName
++        if syncChange {
++            triggerProfileSync()
++        }
++    }
++    
++    private func clearCurrentProfile() {
++        currentProfileName = nil
++        triggerProfileSync()
++    }
++    
++    private func getCurrentProfileName() -> String? {
++        return currentProfileName
++    }
++    
++    private var profilesDirectory: URL {
++        let fileManager = FileManager.default
++        let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
++        return documentsDirectory.appendingPathComponent("LoopProfile")
++    }
++
++    private func createProfileDirectoryIfNotExists() throws {
++        let fileManager = FileManager.default
++        var isDir : ObjCBool = false
++        if !fileManager.fileExists(atPath: profilesDirectory.path, isDirectory: &isDir) {
++            try fileManager.createDirectory(at: profilesDirectory, withIntermediateDirectories: true, attributes: nil)
++        } else if !isDir.boolValue {
++            throw NSError(domain: NSCocoaErrorDomain, code: NSFileWriteFileExistsError, userInfo: nil)
++        }
++    }
++
++    private func getAllProfileFiles() throws -> [URL] {
++        let fileManager = FileManager.default
++        let files = try fileManager.contentsOfDirectory(at: profilesDirectory, includingPropertiesForKeys: nil)
++        return files.filter { $0.pathExtension == "json" }
++    }
++
++    private func encodeProfile(_ profile: Profile) throws -> Data {
++        return try JSONEncoder().encode(profile)
++    }
++
++    private func decodeProfile(from data: Data) throws -> Profile {
++        return try JSONDecoder().decode(Profile.self, from: data)
++    }
++
++    public func sanitizeProfileName(_ name: String) -> String {
++        // Replace problematic characters
++        var sanitized = name.replacingOccurrences(of: ".", with: "_")
++        sanitized = sanitized.replacingOccurrences(of: "<", with: "_")
++
++        // Limit the name to 32 characters
++        if sanitized.count > 32 {
++            sanitized = String(sanitized.prefix(32))
++        }
++
++        return sanitized
++    }
++
++    public func saveProfile(withName name: String) {
++        let sanitizedName = sanitizeProfileName(name)
++
++        do {
++            try createProfileDirectoryIfNotExists()
++
++            if let existingProfile = getProfileReference(withName: sanitizedName) {
++                removeProfile(profileReference: existingProfile)
++            }
++
++            let profile = Profile(
++                name: sanitizedName,
++                correctionRange: (therapySettings.glucoseTargetRangeSchedule?.schedule(for: .milligramsPerDeciliter)!)!,
++                carbRatioSchedule: therapySettings.carbRatioSchedule!,
++                basalRateSchedule: therapySettings.basalRateSchedule!,
++                insulinSensitivitySchedule: (therapySettings.insulinSensitivitySchedule?.schedule(for: .milligramsPerDeciliter)!)!,
++                sortOrder: -1
++            )
++
++            let jsonData = try encodeProfile(profile)
++
++            let dateFormatter = DateFormatter()
++            dateFormatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
++            let fileName = dateFormatter.string(from: Date()) + ".json"
++            let fileURL = profilesDirectory.appendingPathComponent(fileName)
++
++            try jsonData.write(to: fileURL)
++            setCurrentProfile(name: sanitizedName, syncChange: true)
++
++            self.loadProfiles()
++        } catch {
++            print("An error occurred while saving profile: \(error)")
++        }
++    }
++
++    public func renameProfile(oldName: String, newName: String) {
++        let sanitizedProfileName = sanitizeProfileName(newName)
++
++        if currentProfileName == oldName {
++            setCurrentProfile(name: sanitizedProfileName, syncChange: true)
++        }
++        
++        do {
++            guard let profileReference = getProfileReference(withName: oldName) else {
++                print("Profile with old name not found.")
++                return
++            }
++            
++            let profile = try getProfile(from: profileReference)
++            
++            let newProfile = Profile(
++                name: sanitizedProfileName,
++                correctionRange: profile.correctionRange,
++                carbRatioSchedule: profile.carbRatioSchedule,
++                basalRateSchedule: profile.basalRateSchedule,
++                insulinSensitivitySchedule: profile.insulinSensitivitySchedule,
++                sortOrder: profile.sortOrder
++            )
++            
++            if let existingProfile = getProfileReference(withName: sanitizedProfileName) {
++                removeProfile(profileReference: existingProfile)
++            }
++            
++            let jsonData = try encodeProfile(newProfile)
++            let fileURL = profilesDirectory.appendingPathComponent(profileReference.fileName)
++            
++            try jsonData.write(to: fileURL)
++            
++            self.loadProfiles()
++        } catch {
++            print("An error occurred while renaming profile: \(error)")
++        }
++    }
++
++    public func updateProfilesOrder() {
++        for (index, profileReference) in profiles.enumerated() {
++            do {
++                var profile = try getProfile(from: profileReference)
++                let newProfile = Profile(
++                    name: profile.name,
++                    correctionRange: profile.correctionRange,
++                    carbRatioSchedule: profile.carbRatioSchedule,
++                    basalRateSchedule: profile.basalRateSchedule,
++                    insulinSensitivitySchedule: profile.insulinSensitivitySchedule,
++                    sortOrder: index
++                )
++                
++                let jsonData = try encodeProfile(newProfile)
++                let fileURL = profilesDirectory.appendingPathComponent(profileReference.fileName)
++                try jsonData.write(to: fileURL)
++                
++            } catch {
++                print("An error occurred while updating profile order: \(error)")
++            }
++        }
++        loadProfiles()
++    }
++    
++    public func loadProfiles() {
++        do {
++            let profileFiles = try getAllProfileFiles()
++            
++            var newProfiles = [ProfileReference]()
++            for fileURL in profileFiles {
++                let data = try Data(contentsOf: fileURL)
++                let profile = try decodeProfile(from: data)
++                let profileRef = ProfileReference(name: sanitizeProfileName(profile.name), fileName: fileURL.lastPathComponent, sortOrder: profile.sortOrder)
++                newProfiles.append(profileRef)
++            }
++            
++            newProfiles.sort { $0.sortOrder ?? 0 < $1.sortOrder ?? 0 }
++            
++            self.profiles = newProfiles
++        } catch {
++            print("An error occurred while loading profiles: \(error)")
++        }
++    }
++
++    public func loadProfile(profile: Profile, completion: @escaping (LoadProfileResult) -> Void) {
++        if(therapySettings.glucoseTargetRangeSchedule == profile.correctionRange &&
++           therapySettings.carbRatioSchedule == profile.carbRatioSchedule &&
++           therapySettings.basalRateSchedule == profile.basalRateSchedule &&
++           therapySettings.insulinSensitivitySchedule == profile.insulinSensitivitySchedule) {
++            self.setCurrentProfile(name: profile.name, syncChange: true)
++            completion(.success)
++        }
++        else
++        {
++            do {
++                delegate?.syncBasalRateSchedule(items: profile.basalRateSchedule.items, completion: { [weak self] result in
++                    switch result {
++                    case .success(let syncedSchedule):
++                        DispatchQueue.main.async {
++                            let unit = self?.therapySettings.glucoseTargetRangeSchedule?.unit ?? HKUnit.milligramsPerDeciliter
++                            self?.saveCorrectionRange(range: profile.correctionRange.schedule(for: unit)! )
++                            self?.saveCarbRatioSchedule(carbRatioSchedule: profile.carbRatioSchedule)
++                            self?.saveBasalRates(basalRates: syncedSchedule)
++                            self?.saveInsulinSensitivitySchedule(insulinSensitivitySchedule: profile.insulinSensitivitySchedule.schedule(for: unit)!)
++                            print("New profile loaded")
++                            self?.setCurrentProfile(name: profile.name, syncChange: false)
++                            completion(.success)
++                        }
++                    case .failure(let error):
++                        print("An error occurred while syncing basal rates: \(error)")
++                        completion(.failure(error))
++                    }
++                })
++            }
++        }
++    }
++
++    func getProfileReference(withName name: String) -> ProfileReference? {
++        let sanitizedInputName = sanitizeProfileName(name)
++        return profiles.first(where: { sanitizeProfileName($0.name) == sanitizedInputName })
++    }
++
++    public func removeProfile(profile: Profile) {
++        guard let profileReference = getProfileReference(withName: profile.name) else {
++            print("No ProfileReference found for given Profile")
++            return
++        }
++
++        removeProfile(profileReference: profileReference)
++        if getCurrentProfileName() == profile.name {
++            clearCurrentProfile()
++        }
++    }
++
++    public func removeProfile(profileReference: ProfileReference) {
++        do {
++            let fileManager = FileManager.default
++            let fileURL = profilesDirectory.appendingPathComponent(profileReference.fileName)
++            try fileManager.removeItem(at: fileURL)
++            loadProfiles()
++        } catch {
++            print("An error occurred while removing profile: \(error)")
++        }
++    }
++
++    func doesProfileExist(withName name: String) -> Bool {
++        return profiles.contains(where: { $0.name == name })
++    }
++
++    public func getProfile(from profileReference: ProfileReference) throws -> Profile {
++        let fileURL = profilesDirectory.appendingPathComponent(profileReference.fileName)
++        let data = try Data(contentsOf: fileURL)
++        let getProfile = try decodeProfile(from: data)
++        return getProfile
++    }
++
++    public func validateProfile(_ profile: Profile) -> Result<Void, ProfileValidationError> {
++        guard let supportedIncrements = delegate?.pumpSupportedIncrements() else {
++            return .failure(.fileLoadError)
++        }
++
++        // Checking Correction Range Schedule
++        for item in profile.correctionRange.items {
++            let minValue = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: item.value.minValue)
++            let maxValue = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: item.value.maxValue)
++
++            if !(Guardrail.correctionRange.absoluteBounds.contains(minValue) && Guardrail.correctionRange.absoluteBounds.contains(maxValue)) {
++                return .failure(.correctionRangeError)
++            }
++        }
++
++        // Checking Insulin Sensitivity Schedule
++        for item in profile.insulinSensitivitySchedule.items {
++            let value = HKQuantity(unit: HKUnit.milligramsPerDeciliter.unitDivided(by: .internationalUnit()), doubleValue: item.value)
++
++            if !Guardrail.insulinSensitivity.absoluteBounds.contains(value) {
++                return .failure(.insulinSensitivityError)
++            }
++        }
++
++        // Checking Carb Ratio Schedule
++        for item in profile.carbRatioSchedule.items {
++            let value = HKQuantity(unit: .gramsPerUnit, doubleValue: item.value)
++
++            if !Guardrail.carbRatio.absoluteBounds.contains(value) {
++                return .failure(.carbRatioError)
++            }
++        }
++
++        // Checking Basal Rate Schedule
++        if let maximumBasalRate = therapySettings.maximumBasalRatePerHour {
++            for item in profile.basalRateSchedule.items {
++                let value = item.value
++
++                if value > maximumBasalRate || !supportedIncrements.basalRates.contains(value) {
++                    return .failure(.basalRateError)
++                }
++            }
++        } else {
++            return .failure(.maxBasalRateNotSet)
++        }
++
++        return .success(())
++    }
++
++    func isCorrectionRangeEqual(a: GlucoseRangeSchedule, b: GlucoseRangeSchedule) -> Bool {
++        guard a.items.count == b.items.count else {
++            return false
++        }
++        
++        for (item1, item2) in zip(a.items, b.items) {
++            if item1.startTime != item2.startTime ||
++                abs(item1.value.minValue - item2.value.minValue) > 0.01 ||
++                abs(item1.value.maxValue - item2.value.maxValue) > 0.01 {
++                return false
++            }
++        }
++        
++        return true
++    }
++    
++    func isInsulinSensitivityScheduleEqual(a: InsulinSensitivitySchedule, b: InsulinSensitivitySchedule) -> Bool {
++        guard a.items.count == b.items.count else {
++            return false
++        }
++        
++        for (item1, item2) in zip(a.items, b.items) {
++            if item1.startTime != item2.startTime ||
++                abs(item1.value - item2.value) > 0.01 {
++                return false
++            }
++        }
++        
++        return true
++    }
++    
++    public func isCurrentProfileOutOfSync() -> Bool {
++        guard let currentProfileName = self.currentProfileName,
++              let currentProfileReference = profiles.first(where: { $0.name == currentProfileName }),
++              let profile = try? getProfile(from: currentProfileReference),
++              let therapyGlucoseSchedule = therapySettings.glucoseTargetRangeSchedule?.schedule(for: HKUnit.milligramsPerDeciliter),
++              let therapyInsulinSensitivitySchedule = therapySettings.insulinSensitivitySchedule?.schedule(for: HKUnit.milligramsPerDeciliter) else {
++            return false // No current profile set or profile not found or schedules not available
++        }
++        
++        var isOutOfSync = false
++        
++        if !isCorrectionRangeEqual(a: therapyGlucoseSchedule, b: profile.correctionRange.schedule(for: HKUnit.milligramsPerDeciliter)!) {
++            print("Glucose target range schedule differs")
++            isOutOfSync = true
++        }
++        if therapySettings.carbRatioSchedule != profile.carbRatioSchedule {
++            print("Carb ratio schedule differs")
++            isOutOfSync = true
++        }
++        if therapySettings.basalRateSchedule != profile.basalRateSchedule {
++            print("Basal rate schedule differs")
++            isOutOfSync = true
++        }
++        if !isInsulinSensitivityScheduleEqual(a: therapyInsulinSensitivitySchedule, b: profile.insulinSensitivitySchedule.schedule(for: HKUnit.milligramsPerDeciliter)!) {
++            print("Insulin sensitivity schedule differs")
++            isOutOfSync = true
++        }
++        
++        return isOutOfSync
++    }
++}
+diff --git a/LoopKit/LoopKitUI/ViewModels/ProfileViewModel.swift b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel.swift
+new file mode 100644
+index 00000000..a48fa667
+--- /dev/null
++++ b/LoopKit/LoopKitUI/ViewModels/ProfileViewModel.swift
+@@ -0,0 +1,86 @@
++//
++//  ProfileViewModel.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2023-04-22.
++//  Copyright © 2023 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import Combine
++import LoopKit
++import HealthKit
++import SwiftUI
++
++public class ProfileViewModel: ObservableObject {
++    
++    @Published public var therapySettings: TherapySettings
++    @Published public var profiles = [ProfileReference]()
++    @Published public var currentProfileName: String? {
++        didSet {
++            UserDefaults.standard.setValue(currentProfileName, forKey: "currentProfileName")
++        }
++    }
++
++    internal weak var delegate: TherapySettingsViewModelDelegate?
++    
++    public init(therapySettings: TherapySettings,
++                pumpSupportedIncrements: (() -> PumpSupportedIncrements?)? = nil,
++                sensitivityOverridesEnabled: Bool = false,
++                adultChildInsulinModelSelectionEnabled: Bool = false,
++                prescription: Prescription? = nil,
++                delegate: TherapySettingsViewModelDelegate? = nil) {
++        self.therapySettings = therapySettings
++        self.delegate = delegate
++        self.currentProfileName = UserDefaults.standard.string(forKey: "currentProfileName")
++        self.loadProfiles()
++    }
++    
++    public func pumpSupportedIncrements() -> PumpSupportedIncrements? {
++        return delegate?.pumpSupportedIncrements()
++    }
++}
++
++public struct Profile: Codable {
++    let name: String
++    let correctionRange: GlucoseRangeSchedule
++    let carbRatioSchedule: CarbRatioSchedule
++    let basalRateSchedule: BasalRateSchedule
++    let insulinSensitivitySchedule: InsulinSensitivitySchedule
++    var sortOrder: Int?
++}
++
++public struct ProfileReference: Codable, Equatable {
++    var name: String
++    var fileName: String
++    var sortOrder: Int?
++}
++
++
++// MARK: Saving
++extension ProfileViewModel {
++    
++    public func saveCorrectionRange(range: GlucoseRangeSchedule) {
++        therapySettings.glucoseTargetRangeSchedule = range
++        delegate?.saveCompletion(therapySettings: therapySettings)
++    }
++    
++    public func saveBasalRates(basalRates: BasalRateSchedule) {
++        therapySettings.basalRateSchedule = basalRates
++        delegate?.saveCompletion(therapySettings: therapySettings)
++    }
++    
++    public func saveCarbRatioSchedule(carbRatioSchedule: CarbRatioSchedule) {
++        therapySettings.carbRatioSchedule = carbRatioSchedule
++        delegate?.saveCompletion(therapySettings: therapySettings)
++    }
++    
++    public func saveInsulinSensitivitySchedule(insulinSensitivitySchedule: InsulinSensitivitySchedule) {
++        therapySettings.insulinSensitivitySchedule = insulinSensitivitySchedule
++        delegate?.saveCompletion(therapySettings: therapySettings)
++    }
++
++    public func triggerProfileSync() {
++        delegate?.updateCurrentProfileName()
++    }
++}
+diff --git a/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift b/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
+index 3650ef60..c5c1dc01 100644
+--- a/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
++++ b/LoopKit/LoopKitUI/ViewModels/TherapySettingsViewModel.swift
+@@ -16,6 +16,7 @@ public protocol TherapySettingsViewModelDelegate: AnyObject {
+     func syncDeliveryLimits(deliveryLimits: DeliveryLimits, completion: @escaping (Result<DeliveryLimits, Error>) -> Void)
+     func saveCompletion(therapySettings: TherapySettings)
+     func pumpSupportedIncrements() -> PumpSupportedIncrements?
++    func updateCurrentProfileName()
+ }
+ 
+ public class TherapySettingsViewModel: ObservableObject {
+diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/NewProfileEditor.swift b/LoopKit/LoopKitUI/Views/Settings Editors/NewProfileEditor.swift
+new file mode 100644
+index 00000000..446910e4
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/Settings Editors/NewProfileEditor.swift	
+@@ -0,0 +1,79 @@
++//
++//  NewProfileEditor.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2023-05-19.
++//  Copyright © 2023 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import SwiftUI
++
++struct NewProfileEditor: View {
++    @Binding var isPresented: Bool
++    @State var newProfileName: String
++    var viewModel: ProfileViewModel
++    @State private var showAlert = false
++
++    var body: some View {
++        VStack(spacing: 0) {
++            ModalHeaderButtonBar(
++                leading: { cancelButton },
++                center: {
++                    Text("New Profile")
++                        .font(.headline)
++                },
++                trailing: { addButton }
++            )
++
++            TextField("Profile Name", text: $newProfileName)
++                .textFieldStyle(RoundedBorderTextFieldStyle())
++                .padding()
++                .background(
++                    RoundedCorners(radius: 10, corners: [.bottomLeft, .bottomRight])
++                        .fill(Color(.secondarySystemGroupedBackground))
++                )
++        }
++        .padding(.horizontal)
++        .alert(isPresented: $showAlert) {
++            Alert(
++                title: Text("Overwrite Existing Profile"),
++                message: Text("A profile with this name already exists. Would you like to overwrite it?"),
++                primaryButton: .destructive(Text("Overwrite")) {
++                    self.viewModel.saveProfile(withName: self.newProfileName)
++                    self.isPresented = false
++                },
++                secondaryButton: .cancel()
++            )
++        }
++    }
++
++    var addButton: some View {
++        Button(
++            action: {
++                withAnimation {
++                    if viewModel.doesProfileExist(withName: self.newProfileName) {
++                        self.showAlert = true
++                    } else {
++                        self.viewModel.saveProfile(withName: self.newProfileName)
++                        self.isPresented = false
++                    }
++                }
++            }, label: {
++                Text("Add")
++            }
++        )
++    }
++
++    var cancelButton: some View {
++        Button(
++            action: {
++                withAnimation {
++                    self.isPresented = false
++                }
++            }, label: {
++                Text("Cancel")
++            }
++        )
++    }
++}
+diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/ProfilePreviewView.swift b/LoopKit/LoopKitUI/Views/Settings Editors/ProfilePreviewView.swift
+new file mode 100644
+index 00000000..6de3598f
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/Settings Editors/ProfilePreviewView.swift	
+@@ -0,0 +1,326 @@
++//
++//  ProfilePreviewView.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2023-05-23.
++//  Copyright © 2023 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import SwiftUI
++import HealthKit
++import LoopKit
++
++enum ActiveAlert {
++    case load
++    case delete
++    case error
++}
++
++struct ProfilePreviewView: View {
++    @EnvironmentObject private var displayGlucosePreference: DisplayGlucosePreference
++    @ObservedObject var viewModel: ProfileViewModel
++    @Environment(\.dismissAction) var dismissAction
++    @Environment(\.presentationMode) var presentationMode
++    var profile: Profile
++
++    @State private var showingAlert = false
++    @State private var activeAlert: ActiveAlert = .load
++    @State private var errorText: String?
++    @State private var newProfileName: String = ""
++    @State private var isRenamingProfile = false
++    @State private var shouldDismissSelf: Bool = false
++
++    let nilDestination: (_ dismiss: @escaping () -> Void) -> AnyView = { _ in AnyView(EmptyView()) }
++
++    var body: some View {
++        ZStack {
++            ScrollView {
++                VStack(alignment: .leading) {
++                    Text("Before proceeding, review the profile details below. Scroll to find options to Load, Rename, or Delete.")
++                        .font(.body)
++                        .foregroundColor(.primary)
++                        .padding([.leading, .trailing])
++                        .fixedSize(horizontal: false, vertical: true)
++                        .textCase(nil)
++                    
++                    profileCardStack
++                    
++                    Button(action: {
++                        activeAlert = .load
++                        showingAlert = true
++                    }) {
++                        HStack {
++                            Spacer()
++                            Text("Load")
++                                .foregroundColor(.white)
++                                .padding()
++                            Spacer()
++                        }
++                    }
++                    .background(Color.blue)
++                    .cornerRadius(10)
++                    .padding(.horizontal)
++                    
++                    Button(action: {
++                        isRenamingProfile = true
++                    }) {
++                        HStack {
++                            Spacer()
++                            Text("Rename")
++                                .foregroundColor(.white)
++                                .padding()
++                            Spacer()
++                        }
++                    }
++                    .background(Color.orange)
++                    .cornerRadius(10)
++                    .padding(.horizontal)
++                    
++                    Button(action: {
++                        activeAlert = .delete
++                        showingAlert = true
++                    }) {
++                        HStack {
++                            Spacer()
++                            Text("Delete")
++                                .foregroundColor(.white)
++                                .padding()
++                            Spacer()
++                        }
++                    }
++                    .background(Color.red)
++                    .cornerRadius(10)
++                    .padding(.horizontal)
++                    
++                }
++            }
++            .navigationBarHidden(false)
++            .background(Color(.systemGroupedBackground))
++            .navigationTitle(Text(profile.name))
++            .alert(isPresented: $showingAlert) {
++                switch activeAlert {
++                case .load:
++                    return Alert(
++                        title: Text("Load Profile"),
++                        message: Text("Do you want to load the profile \(profile.name)?"),
++                        primaryButton: .default(Text("Yes"), action: {
++                            let validationResult = viewModel.validateProfile(profile)
++                            switch validationResult {
++                            case .success:
++                                viewModel.loadProfile(profile: profile) { result in
++                                    switch result {
++                                    case .success:
++                                        dismissAction()
++                                    case .failure(let error):
++                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
++                                            self.errorText = error.localizedDescription
++                                            self.activeAlert = .error
++                                            self.showingAlert = true
++                                        }
++                                    }
++                                }
++                            case .failure(let error):
++                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
++                                    self.errorText = error.localizedDescription
++                                    self.activeAlert = .error
++                                    self.showingAlert = true
++                                }
++                            }
++                        }),
++                        secondaryButton: .cancel()
++                    )
++                case .delete:
++                    return Alert(
++                        title: Text("Delete Profile"),
++                        message: Text("Are you sure you want to delete the profile \(profile.name)? This action cannot be undone."),
++                        primaryButton: .destructive(Text("Delete"), action: {
++                            viewModel.removeProfile(profile: profile)
++                            self.presentationMode.wrappedValue.dismiss()
++                        }),
++                        secondaryButton: .cancel()
++                    )
++                case .error:
++                    return Alert(
++                        title: Text("Error loading profile"),
++                        message: Text(errorText ?? "Unknown error"),
++                        dismissButton: .default(Text("OK"))
++                    )
++                }
++            }
++            if isRenamingProfile {
++                // Some hacks here to mimic Alert behaviour.
++                // This function should be migrateed to Alert when iOS 16 is required.
++                Color.black.opacity(0.5)
++                    .edgesIgnoringSafeArea(.all)
++                    .onTapGesture {
++                        isRenamingProfile = false
++                    }
++                
++                RenameProfileEditor(
++                    isPresented: $isRenamingProfile,
++                    currentProfileName: profile.name,
++                    viewModel: viewModel,
++                    shouldDismissParent: $shouldDismissSelf
++                )
++                .transition(AnyTransition.move(edge: .bottom).combined(with: .opacity).animation(.default))
++                .offset(y: -22)
++            }
++        }
++        .onChange(of: shouldDismissSelf) { shouldDismiss in
++            if shouldDismiss {
++                self.presentationMode.wrappedValue.dismiss()
++            }
++        }
++    }
++
++    private var profileCardStack: CardStack {
++        var cards: [Card] = []
++
++        cards.append(correctionRangeSection)
++        cards.append(carbRatioSection)
++        cards.append(basalRatesSection)
++        cards.append(insulinSensitivitiesSection)
++
++        return CardStack(cards: cards)
++    }
++
++    private var correctionRangeSection: Card {
++        card(for: .glucoseTargetRange) {
++            if let items = profile.correctionRange.schedule(for: glucoseUnit)?.items {
++                SectionDivider()
++                ForEach(items.indices, id: \.self) { index in
++                    if index > 0 {
++                        SettingsDivider()
++                    }
++
++                    ScheduleRangeItem(time: items[index].startTime,
++                                      range: items[index].value,
++                                      unit: glucoseUnit,
++                                      guardrail: .correctionRange)
++                }
++            }
++        }
++    }
++
++    private var carbRatioSection: Card {
++        card(for: .carbRatio) {
++            SectionDivider()
++            let items = profile.carbRatioSchedule.items
++            ForEach(items.indices, id: \.self) { index in
++                if index > 0 {
++                    SettingsDivider()
++                }
++
++                ScheduleValueItem(time: items[index].startTime,
++                                  value: items[index].value,
++                                  unit: .gramsPerUnit,
++                                  guardrail: .carbRatio)
++            }
++        }
++    }
++
++    private var basalRatesSection: Card {
++        card(for: .basalRate) {
++            let items = profile.basalRateSchedule.items
++            if let supportedBasalRates = viewModel.pumpSupportedIncrements()?.basalRates
++            {
++                SectionDivider()
++                let total = profile.basalRateSchedule.total()
++                ForEach(items.indices, id: \.self) { index in
++                    if index > 0 {
++                        SettingsDivider()
++                    }
++
++                    ScheduleValueItem(time: items[index].startTime,
++                                      value:  items[index].value,
++                                      unit: .internationalUnitsPerHour,
++                                      guardrail: .basalRate(supportedBasalRates: supportedBasalRates))
++                }
++                HStack {
++                    Text("Total")
++                        .bold()
++                        .foregroundColor(.primary)
++                    Spacer()
++                    Text(String(format: "%.2f ",total))
++                        .foregroundColor(.primary) +
++                    Text("U/day")
++                        .foregroundColor(.secondary)
++                }
++            }
++        }
++    }
++
++    private var insulinSensitivitiesSection: Card {
++        card(for: .insulinSensitivity) {
++            if let items = profile.insulinSensitivitySchedule.schedule(for: glucoseUnit)?.items
++            {
++                SectionDivider()
++                ForEach(items.indices, id: \.self) { index in
++                    if index > 0 {
++                        SettingsDivider()
++                    }
++                    ScheduleValueItem(time: items[index].startTime,
++                                      value: items[index].value,
++                                      unit: sensitivityUnit,
++                                      guardrail: .insulinSensitivity)
++                }
++            }
++        }
++    }
++}
++
++
++struct SectionWithContent<Content>: View where Content: View {
++    let title: String
++    let content: Content
++
++    init(title: String,
++         content: () -> Content)
++    {
++        self.title = title
++        self.content = content()
++    }
++
++    public var body: some View {
++        Section {
++            Text(title)
++                .bold()
++                .frame(maxWidth: .infinity, alignment: .leading)
++            content
++        }
++    }
++}
++
++// MARK: Utilities
++extension ProfilePreviewView {
++
++    private var glucoseUnit: HKUnit {
++        displayGlucosePreference.unit
++    }
++
++    private var sensitivityUnit: HKUnit {
++        glucoseUnit.unitDivided(by: .internationalUnit())
++    }
++
++    private func card<Content>(for therapySetting: TherapySetting, @ViewBuilder content: @escaping () -> Content) -> Card where Content: View {
++        Card {
++            SectionWithContent(title: therapySetting.title,
++                               content: content)
++        }
++    }
++}
++
++fileprivate struct SectionDivider: View {
++    var body: some View {
++        Divider()
++            .padding(.trailing, -16)
++    }
++}
++
++fileprivate struct SettingsDivider: View {
++    var body: some View {
++        Divider()
++            .padding(.trailing, -8)
++    }
++}
+diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/ProfileView.swift b/LoopKit/LoopKitUI/Views/Settings Editors/ProfileView.swift
+new file mode 100644
+index 00000000..1c6244a4
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/Settings Editors/ProfileView.swift	
+@@ -0,0 +1,173 @@
++//
++//  ProfileView.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2023-04-22.
++//  Copyright © 2023 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import AVFoundation
++import HealthKit
++import LoopKit
++import SwiftUI
++
++public struct ProfileView: View {
++    @ObservedObject public var viewModel: ProfileViewModel
++    @Environment(\.dismissAction) var dismissAction
++    @State private var newProfileName: String = ""
++    @State private var isAddingNewProfile = false
++    @State private var selectedProfileIndex: Int? = nil
++    @State private var refreshID = UUID()
++
++    enum ActiveAlert: String, Identifiable {
++        case update, info
++        
++        var id: String {
++            return self.rawValue
++        }
++    }
++    @State private var activeAlert: ActiveAlert?
++    
++    public init(viewModel: ProfileViewModel) {
++        self.viewModel = viewModel
++    }
++    
++    private var dismissButton: some View {
++        Button(action: dismissAction) {
++            Text(LocalizedString("Done", comment: "Text for dismiss button"))
++                .bold()
++        }
++    }
++    
++    public var body: some View {
++        ZStack {
++            NavigationView {
++                ConfigurationPageScrollView(
++                    content: {
++                        VStack(alignment: .leading) {
++                            
++                            if !viewModel.profiles.isEmpty {
++                                List {
++                                    ForEach(viewModel.profiles.indices, id: \.self) { index in
++                                        if let profile = try? viewModel.getProfile(from: viewModel.profiles[index]) {
++                                            NavigationLink(destination: ProfilePreviewView(viewModel: viewModel, profile: profile)) {
++                                                HStack {
++                                                    if viewModel.currentProfileName == viewModel.profiles[index].name {
++                                                        Image(systemName: "checkmark")
++                                                            .foregroundColor(Color.blue)
++                                                    } else {
++                                                        // Add indentation to align with the checkmark for the active profile
++                                                        Image(systemName: "checkmark")
++                                                            .opacity(0) // Invisible
++                                                    }
++                                                    
++                                                    Text(viewModel.profiles[index].name)
++                                                }
++                                            }
++                                        }
++                                    }
++                                    .onMove(perform: moveProfile)
++                                }.id(refreshID)
++                                
++                            } else {
++                                Text("Use ‘+’ to create a new profile capturing your glucose targets, carb ratios, basal rates, and insulin sensitivities.")
++                                    .font(.subheadline)
++                                    .foregroundColor(.secondary)
++                                    .padding([.leading, .trailing])
++                                    .multilineTextAlignment(.leading)
++                                    .lineLimit(nil)
++                                    .textCase(nil)
++                            }
++                        }
++                    },
++                    actionArea: { EmptyView() } // no action area in this case
++                )
++                .navigationBarItems(
++                    leading: HStack {
++                        Button(action: { withAnimation { isAddingNewProfile = true } }) {
++                            Image(systemName: "plus")
++                        }
++                        
++                        Button(action: { activeAlert = .info }) {
++                            Image(systemName: "info.circle")
++                                .resizable()
++                                .frame(width: 24, height: 24)
++                        }
++                    },
++                    trailing: dismissButton
++                )
++                .navigationTitle(Text(LocalizedString("Profiles", comment: "Title on ProfileView")))
++            }
++            .navigationBarHidden(false)
++            .background(Color(.systemGroupedBackground))
++            .onAppear {
++                if viewModel.isCurrentProfileOutOfSync() {
++                    activeAlert = .update
++                }
++            }
++            
++            .alert(item: $activeAlert) { alertType in
++                switch alertType {
++                case .update:
++                    return Alert(
++                        title: Text("Profile Outdated"),
++                        message: Text("The current therapy settings have changed. Do you want to update the profile named: \(viewModel.currentProfileName ?? "")?"),
++                        primaryButton: .default(Text("Update")) {
++                            viewModel.saveProfile(withName: viewModel.currentProfileName ?? "")
++                        },
++                        secondaryButton: .cancel()
++                    )
++                case .info:
++                    return Alert(title: Text("Information"),
++                                 message: Text("A checkmark next to a profile name indicates that it's the active one.\n\nUse ‘+’ to create a new profile capturing your glucose targets, carb ratios, basal rates, and insulin sensitivities.\n\nTap on any profile to review its settings in detail. In detail view, you can Load, Rename or Delete that particular profile.\n\nWant to change the order of profiles? Simply press and hold on a profile, then drag it to your desired position."),
++                                 dismissButton: .default(Text("Got it!")))
++                }
++            }
++            
++            if isAddingNewProfile {
++                DarkenedOverlay()
++                
++                NewProfileEditor(
++                    isPresented: $isAddingNewProfile,
++                    newProfileName: newProfileName,
++                    viewModel: viewModel
++                )
++                .transition(AnyTransition.move(edge: .bottom).combined(with: .opacity).animation(.default))
++            }
++        }
++    }
++    
++    func moveProfile(from source: IndexSet, to destination: Int) {
++        viewModel.profiles.move(fromOffsets: source, toOffset: destination)
++        refreshID = UUID()
++        viewModel.updateProfilesOrder()
++    }
++}
++
++struct ProfileView_Previews: PreviewProvider {
++    static let preview_glucoseScheduleItems = [
++        RepeatingScheduleValue(startTime: 0, value: DoubleRange(80...90)),
++        RepeatingScheduleValue(startTime: 1800, value: DoubleRange(90...100)),
++        RepeatingScheduleValue(startTime: 3600, value: DoubleRange(100...110))
++    ]
++    
++    static let preview_therapySettings = TherapySettings(
++        glucoseTargetRangeSchedule: GlucoseRangeSchedule(unit: .milligramsPerDeciliter, dailyItems: preview_glucoseScheduleItems),
++        correctionRangeOverrides: CorrectionRangeOverrides(preMeal: DoubleRange(88...99),
++                                                           workout: DoubleRange(99...111),
++                                                           unit: .milligramsPerDeciliter),
++        maximumBolus: 4,
++        suspendThreshold: GlucoseThreshold.init(unit: .milligramsPerDeciliter, value: 60),
++        insulinSensitivitySchedule: InsulinSensitivitySchedule(unit: HKUnit.milligramsPerDeciliter.unitDivided(by: HKUnit.internationalUnit()), dailyItems: []),
++        carbRatioSchedule: nil,
++        basalRateSchedule: BasalRateSchedule(dailyItems: [RepeatingScheduleValue(startTime: 0, value: 0.2), RepeatingScheduleValue(startTime: 1800, value: 0.75)]))
++    
++    static let preview_supportedBasalRates = [0.2, 0.5, 0.75, 1.0]
++    static let preview_supportedBolusVolumes = [1.0, 2.0, 3.0]
++    static let preview_supportedMaximumBolusVolumes = [5.0, 10.0, 15.0]
++    
++    static var previews: some View {
++        ProfileView(viewModel: ProfileViewModel(therapySettings: preview_therapySettings))
++    }
++}
+diff --git a/LoopKit/LoopKitUI/Views/Settings Editors/RenameProfileEditor.swift b/LoopKit/LoopKitUI/Views/Settings Editors/RenameProfileEditor.swift
+new file mode 100644
+index 00000000..8fd26665
+--- /dev/null
++++ b/LoopKit/LoopKitUI/Views/Settings Editors/RenameProfileEditor.swift	
+@@ -0,0 +1,92 @@
++//
++//  RenameProfileEditor.swift
++//  LoopKitUI
++//
++//  Created by Jonas Björkert on 2023-09-07.
++//  Copyright © 2023 LoopKit Authors. All rights reserved.
++//
++
++import Foundation
++import SwiftUI
++
++struct RenameProfileEditor: View {
++    @Binding var isPresented: Bool
++    @State var currentProfileName: String
++    @State var newProfileName: String = ""
++    var viewModel: ProfileViewModel
++    @State private var showAlert = false
++    @Binding var shouldDismissParent: Bool
++
++    var body: some View {
++        VStack(spacing: 0) {
++            ModalHeaderButtonBar(
++                leading: { cancelButton },
++                center: {
++                    Text("Rename Profile")
++                        .font(.subheadline)
++
++                },
++                trailing: { renameButton }
++            )
++            .onAppear {
++                self.newProfileName = currentProfileName
++            }
++            
++            TextField("Profile Name", text: $newProfileName)
++                .textFieldStyle(RoundedBorderTextFieldStyle())
++                .padding()
++                .background(
++                    RoundedCorners(radius: 10, corners: [.bottomLeft, .bottomRight])
++                        .fill(Color(.secondarySystemGroupedBackground))
++                )
++        }
++        .padding(.horizontal)
++        .alert(isPresented: $showAlert) {
++            Alert(
++                title: Text("Overwrite Existing Profile"),
++                message: Text("A profile with this name already exists. Would you like to overwrite it?"),
++                primaryButton: .destructive(Text("Overwrite")) {
++                    self.viewModel.renameProfile(oldName: currentProfileName, newName: self.newProfileName)
++                    self.shouldDismissParent = true
++                    self.isPresented = false
++                },
++                secondaryButton: .cancel()
++            )
++        }
++    }
++    
++    var renameButton: some View {
++        Button(
++            action: {
++                withAnimation {
++                    guard newProfileName != currentProfileName else {
++                        self.isPresented = false
++                        return
++                    }
++
++                    if viewModel.doesProfileExist(withName: self.newProfileName) {
++                        self.showAlert = true
++                    } else {
++                        self.viewModel.renameProfile(oldName: currentProfileName, newName: self.newProfileName)
++                        self.shouldDismissParent = true
++                        self.isPresented = false
++                    }
++                }
++            }, label: {
++                Text("Rename")
++            }
++        )
++    }
++    
++    var cancelButton: some View {
++        Button(
++            action: {
++                withAnimation {
++                    self.isPresented = false
++                }
++            }, label: {
++                Text("Cancel")
++            }
++        )
++    }
++}
+Submodule LoopOnboarding 4c5c192..a25529c:
+diff --git a/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift b/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift
+index cc61f2d..6462e2c 100644
+--- a/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift	
++++ b/LoopOnboarding/LoopOnboardingKitUI/View Controllers/OnboardingUICoordinator.swift	
+@@ -379,6 +379,9 @@ extension OnboardingUICoordinator: TherapySettingsViewModelDelegate {
+             maximumBasalScheduleEntryCount: maximumBasalScheduleEntryCount
+         )
+     }
++    
++    func updateCurrentProfileName() {
++    }
+ }
+ 
+ 
+Submodule NightscoutService d839b66..0da2cd4:
+diff --git a/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift b/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift
+index 0bed9c6..7d6c12d 100644
+--- a/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift
++++ b/NightscoutService/NightscoutServiceKit/Extensions/StoredSettings.swift
+@@ -94,12 +94,20 @@ extension StoredSettings {
+             return nil
+         }
+ 
++        var store = ["Default": profile]
++        var defaultProfile = "Default"
++
++        if let name = UserDefaults.standard.string(forKey: "currentProfileName") {
++            defaultProfile = name
++            store[name] = profile
++        }
++
+         return ProfileSet(
+             startDate: date,
+             units: bloodGlucoseUnit.shortLocalizedUnitString(avoidLineBreaking: false),
+             enteredBy: "Loop",
+-            defaultProfile: "Default",
+-            store: ["Default": profile],
++            defaultProfile: defaultProfile,
++            store: store,
+             settings: loopSettings,
+             syncIdentifier: syncIdentifier.uuidString)
+     }


### PR DESCRIPTION
Several of the Customizations stopped working with the LoopWorkspace dev v3.7.7.

Modify the customizations that are incompatible
* profiles
* basal_lock 
* live_activity 

And because negative_insulin requires a special version to work when live_activity is also used, modify the paired patches for combining negative_insulin and live_activity that allow the user to select those in any order.

All the changes were associated with diffs in pbxproj files where the change needed to define the customization was near an item changed when converting from *.strings files to *.xcstrings with the use of String Catalogs in LoopWorkspace dev, v3.7.7.