### PR TITLE
Add xDrip4iOS CGM customization (xdrip_cgm)

### DIFF
--- a/xdrip_cgm/xdrip_cgm.patch
+++ b/xdrip_cgm/xdrip_cgm.patch
@@ -1,32 +1,37 @@
 diff --git a/.gitmodules b/.gitmodules
-index f3472ea..91b8525 100644
+index f3472ea..7e74758 100644
 --- a/.gitmodules
 +++ b/.gitmodules
-@@ -61,3 +61,6 @@
- [submodule "EversenseKit"]
- 	path = EversenseKit
- 	url = https://github.com/bastiaanv/EversenseKit
+@@ -10,6 +10,9 @@
+ [submodule "dexcom-share-client-swift"]
+ 	path = dexcom-share-client-swift
+ 	url = https://github.com/LoopKit/dexcom-share-client-swift.git
 +[submodule "xdrip-client-swift"]
 +	path = xdrip-client-swift
 +	url = https://github.com/johandegraeve/xdrip-client-swift-1.git
+ [submodule "RileyLinkKit"]
+ 	path = RileyLinkKit
+ 	url = https://github.com/LoopKit/RileyLinkKit
 diff --git a/LoopWorkspace.xcworkspace/contents.xcworkspacedata b/LoopWorkspace.xcworkspace/contents.xcworkspacedata
-index fed13e7..c4fdd8b 100644
+index fed13e7..0247b29 100644
 --- a/LoopWorkspace.xcworkspace/contents.xcworkspacedata
 +++ b/LoopWorkspace.xcworkspace/contents.xcworkspacedata
-@@ -135,4 +135,7 @@
+@@ -87,6 +87,9 @@
     <FileRef
-       location = "group:LoopOnboarding/LoopOnboarding.xcodeproj">
+       location = "group:dexcom-share-client-swift/ShareClient.xcodeproj">
     </FileRef>
 +   <FileRef
 +      location = "group:xdrip-client-swift/xDripClient.xcodeproj">
 +   </FileRef>
- </Workspace>
+    <FileRef
+       location = "group:AmplitudeService/AmplitudeService.xcodeproj">
+    </FileRef>
 diff --git a/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme b/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
-index 19f95ce..d381222 100644
+index 19f95ce..6510de6 100644
 --- a/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
 +++ b/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
-@@ -174,6 +174,20 @@
-                ReferencedContainer = "container:OmnipodKit/OmnipodKit.xcodeproj">
+@@ -188,6 +188,20 @@
+                ReferencedContainer = "container:dexcom-share-client-swift/ShareClient.xcodeproj">
              </BuildableReference>
           </BuildActionEntry>
 +         <BuildActionEntry

--- a/xdrip_cgm/xdrip_cgm.patch
+++ b/xdrip_cgm/xdrip_cgm.patch
@@ -1,0 +1,48 @@
+diff --git a/.gitmodules b/.gitmodules
+index f3472ea..91b8525 100644
+--- a/.gitmodules
++++ b/.gitmodules
+@@ -61,3 +61,6 @@
+ [submodule "EversenseKit"]
+ 	path = EversenseKit
+ 	url = https://github.com/bastiaanv/EversenseKit
++[submodule "xdrip-client-swift"]
++	path = xdrip-client-swift
++	url = https://github.com/johandegraeve/xdrip-client-swift-1.git
+diff --git a/LoopWorkspace.xcworkspace/contents.xcworkspacedata b/LoopWorkspace.xcworkspace/contents.xcworkspacedata
+index fed13e7..c4fdd8b 100644
+--- a/LoopWorkspace.xcworkspace/contents.xcworkspacedata
++++ b/LoopWorkspace.xcworkspace/contents.xcworkspacedata
+@@ -135,4 +135,7 @@
+    <FileRef
+       location = "group:LoopOnboarding/LoopOnboarding.xcodeproj">
+    </FileRef>
++   <FileRef
++      location = "group:xdrip-client-swift/xDripClient.xcodeproj">
++   </FileRef>
+ </Workspace>
+diff --git a/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme b/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
+index 19f95ce..d381222 100644
+--- a/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
++++ b/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
+@@ -174,6 +174,20 @@
+                ReferencedContainer = "container:OmnipodKit/OmnipodKit.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
++         <BuildActionEntry
++            buildForTesting = "YES"
++            buildForRunning = "YES"
++            buildForProfiling = "YES"
++            buildForArchiving = "YES"
++            buildForAnalyzing = "YES">
++            <BuildableReference
++               BuildableIdentifier = "primary"
++               BlueprintIdentifier = "C187C196279086A8006E3557"
++               BuildableName = "xDripClientPlugin.loopplugin"
++               BlueprintName = "xDripClientPlugin"
++               ReferencedContainer = "container:xdrip-client-swift/xDripClient.xcodeproj">
++            </BuildableReference>
++         </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"


### PR DESCRIPTION
## Purpose

Add a customization that enables **xDrip4iOS as a CGM** source for Loop via a shared App Group.

The patch that was previously circulated for this no longer applies to current LoopWorkspace: the separate `OmniBLE`/`OmniKit` plugins were consolidated into a single `OmnipodKit` plugin, so the `OmniBLE/OmniBLE.xcodeproj` scheme entry that the old patch anchored on is gone, and `git apply` rejects the whole patch.

## Method

New `xdrip_cgm/` folder with `xdrip_cgm.patch`, re-anchored on the `OmnipodKitPlugin` scheme entry. It adds:

* the `xdrip-client-swift` submodule to `.gitmodules`
* the `xDripClient.xcodeproj` reference to the workspace
* the `xDripClientPlugin` build entry to the `LoopWorkspace` scheme

The `dev` and `main` schemes are currently identical, so a single patch covers both.

## Dependency

Requires the matching lnl-scripts PR loopandlearn/lnl-scripts#98 (branch `xdrip_cgm`), which adds the menu entry and clones the `xdrip-client-swift` source after the patch is applied. The test commands below already fetch the script from that branch.

## Test

Tested against LoopWorkspace `main` and `dev` (schemes are identical); the patch applies and reverses cleanly.

### reset command

This command resets the branch to default state.
```
git submodule foreach 'git reset --hard; git clean -fd;'
```

### apply

```
export PATCH_BRANCH="xdrip_cgm"
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/loopandlearn/lnl-scripts/xdrip_cgm/CustomizationSelect.sh)" \
    xdrip_cgm
unset PATCH_BRANCH
```

Then confirm `xdrip-client-swift/xDripClient.xcodeproj` is present and that LoopWorkspace builds with xDrip4iOS available as a CGM.
